### PR TITLE
Extracting base navigation logic for Navigators (backwards compatable)

### DIFF
--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
@@ -2,17 +2,13 @@ package ru.terrakok.cicerone.android;
 
 import android.app.Activity;
 import android.app.FragmentManager;
+import android.content.Context;
 import android.content.Intent;
-import android.widget.Toast;
 
-import ru.terrakok.cicerone.commands.BackTo;
-import ru.terrakok.cicerone.commands.Command;
-import ru.terrakok.cicerone.commands.Forward;
-import ru.terrakok.cicerone.commands.Replace;
+import ru.terrakok.cicerone.android.adapters.ActivityAdapter;
 
 /**
- * Extends {@link FragmentNavigator} to allow
- * open new or replace current activity.
+ * Allow open new or replace current activity.
  * <p>
  * This navigator DOESN'T provide full featured Activity navigation,
  * but can ease Activity start or replace from current navigator.
@@ -20,74 +16,37 @@ import ru.terrakok.cicerone.commands.Replace;
  *
  * @author Vasili Chyrvon (vasili.chyrvon@gmail.com)
  */
-public abstract class AppNavigator extends FragmentNavigator {
+public abstract class AppNavigator extends AppNavigatorBase {
 
-    private Activity activity;
-
-    public AppNavigator(Activity activity, int containerId) {
-        super(activity.getFragmentManager(), containerId);
-        this.activity = activity;
+    public AppNavigator(Activity activity, @Deprecated int containerId) {
+        super(new AndroidActivityAdapter(activity));
     }
 
-    public AppNavigator(Activity activity, FragmentManager fragmentManager, int containerId) {
-        super(fragmentManager, containerId);
-        this.activity = activity;
+    @Deprecated
+    public AppNavigator(Activity activity, @Deprecated FragmentManager fragmentManager, @Deprecated int containerId) {
+        this(activity, containerId);
     }
 
-    /**
-     * Opens new screen based on the passed command.
-     *
-     * @param forward forward command to apply
-     */
-    @Override
-    protected void applyForward(Forward forward) {
-        Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
+    private static class AndroidActivityAdapter implements ActivityAdapter {
+        private final Activity activity;
 
-        // Start activity
-        if (activityIntent != null) {
-            activity.startActivity(activityIntent);
-            return;
+        public AndroidActivityAdapter(Activity activity) {
+            this.activity = activity;
         }
-    }
 
-    /**
-     * Replaces the current screen based on the passed command.
-     *
-     * @param replace replace command to apply
-     */
-    @Override
-    protected void applyReplace(Replace replace) {
-        Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
-
-        // Replace activity
-        if (activityIntent != null) {
+        @Override
+        public void startActivity(Intent activityIntent) {
             activity.startActivity(activityIntent);
+        }
+
+        @Override
+        public void finish() {
             activity.finish();
-            return;
         }
-    }
 
-    /**
-     * Creates Intent to start Activity for {@code screenKey}.
-     * <p>
-     * <b>Warning:</b> This method does not work with {@link BackTo} command.
-     * </p>
-     *
-     * @param screenKey screen key
-     * @param data      initialization data, can be null
-     * @return intent to start Activity for the passed screen key
-     */
-    protected abstract Intent createActivityIntent(String screenKey, Object data);
-
-    @Override
-    protected void showSystemMessage(String message) {
-        // Toast by default
-        Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    protected void exit() {
-        // Finish by default
-        activity.finish();
+        @Override
+        public Context getContext() {
+            return activity;
+        }
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
@@ -34,32 +34,37 @@ public abstract class AppNavigator extends FragmentNavigator {
         this.activity = activity;
     }
 
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
     @Override
-    public void applyCommand(Command command) {
-        if (command instanceof Forward) {
-            Forward forward = (Forward) command;
-            Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
+    protected void applyForward(Forward forward) {
+        Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
 
-            // Start activity
-            if (activityIntent != null) {
-                activity.startActivity(activityIntent);
-                return;
-            }
-
-        } else if (command instanceof Replace) {
-            Replace replace = (Replace) command;
-            Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
-
-            // Replace activity
-            if (activityIntent != null) {
-                activity.startActivity(activityIntent);
-                activity.finish();
-                return;
-            }
+        // Start activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            return;
         }
+    }
 
-        // Use default fragments navigation
-        super.applyCommand(command);
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    @Override
+    protected void applyReplace(Replace replace) {
+        Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
+
+        // Replace activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            activity.finish();
+            return;
+        }
     }
 
     /**

--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
@@ -1,6 +1,7 @@
 package ru.terrakok.cicerone.android;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Context;
 import android.content.Intent;
@@ -26,6 +27,16 @@ public abstract class AppNavigator extends AppNavigatorBase {
     public AppNavigator(Activity activity, @Deprecated FragmentManager fragmentManager, @Deprecated int containerId) {
         this(activity, containerId);
     }
+
+    /**
+     * Creates Fragment matching {@code screenKey}.
+     *
+     * @param screenKey screen key
+     * @param data      initialization data
+     * @return instantiated fragment for the passed screen key
+     */
+    @Deprecated
+    protected abstract Fragment createFragment(String screenKey, Object data);
 
     private static class AndroidActivityAdapter implements ActivityAdapter {
         private final Activity activity;

--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigatorBase.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigatorBase.java
@@ -80,6 +80,14 @@ abstract class AppNavigatorBase extends NavigatorBase {
     }
 
     /**
+     * Called when we tried to back to some specific screen, but didn't found it.
+     */
+    @Override
+    protected void backToUnexisting() {
+
+    }
+
+    /**
      * Creates Intent to start Activity for {@code screenKey}.
      * <p>
      * <b>Warning:</b> This method does not work with {@link BackTo} command.

--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigatorBase.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigatorBase.java
@@ -1,0 +1,113 @@
+package ru.terrakok.cicerone.android;
+
+
+import android.content.Intent;
+import android.widget.Toast;
+
+import ru.terrakok.cicerone.android.adapters.ActivityAdapter;
+import ru.terrakok.cicerone.commands.Back;
+import ru.terrakok.cicerone.commands.BackTo;
+import ru.terrakok.cicerone.commands.Forward;
+import ru.terrakok.cicerone.commands.Replace;
+
+/**
+ * Allow open new or replace current activity.
+ * <p>
+ * This navigator DOESN'T provide full featured Activity navigation,
+ * but can ease Activity start or replace from current navigator.
+ * </p>
+ *
+ * @author Vasili Chyrvon (vasili.chyrvon@gmail.com)
+ */
+abstract class AppNavigatorBase extends NavigatorBase {
+    private final ActivityAdapter activity;
+
+    protected AppNavigatorBase(ActivityAdapter activity) {
+        this.activity = activity;
+    }
+
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
+    @Override
+    protected void applyForward(Forward forward) {
+        Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
+
+        // Start activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            return;
+        }
+    }
+
+    /**
+     * Rolls back the last transition from the screens chain based on the passed command.
+     *
+     * @param back back command to apply
+     */
+    @Override
+    protected void applyBack(Back back) {
+
+    }
+
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    @Override
+    protected void applyReplace(Replace replace) {
+        Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
+
+        // Replace activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            activity.finish();
+            return;
+        }
+    }
+
+    /**
+     * Rolls back to the needed screen from the screens chain based on the passed command.
+     *
+     * @param backTo backTo command to apply
+     */
+    @Override
+    protected void applyBackTo(BackTo backTo) {
+
+    }
+
+    /**
+     * Creates Intent to start Activity for {@code screenKey}.
+     * <p>
+     * <b>Warning:</b> This method does not work with {@link BackTo} command.
+     * </p>
+     *
+     * @param screenKey screen key
+     * @param data      initialization data, can be null
+     * @return intent to start Activity for the passed screen key
+     */
+    protected abstract Intent createActivityIntent(String screenKey, Object data);
+
+    /**
+     * Shows system message.
+     *
+     * @param message message to show
+     */
+    @Override
+    protected void showSystemMessage(String message) {
+        // Toast by default
+        Toast.makeText(activity.getContext(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    /**
+     * Called when we try to back from the root.
+     */
+    @Override
+    protected void exit() {
+        // Finish by default
+        activity.finish();
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/FragmentNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/FragmentNavigator.java
@@ -4,10 +4,9 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 
 import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.android.adapters.AndroidFragmentManagerAdapter;
 import ru.terrakok.cicerone.commands.Back;
 import ru.terrakok.cicerone.commands.BackTo;
-import ru.terrakok.cicerone.commands.Forward;
-import ru.terrakok.cicerone.commands.Replace;
 
 /**
  * Created by Konstantin Tckhovrebov (aka @terrakok)
@@ -25,10 +24,7 @@ import ru.terrakok.cicerone.commands.Replace;
  * {@link Back} command will call {@link #exit()} method if current screen is the root.
  * </p>
  */
-public abstract class FragmentNavigator extends NavigatorBase {
-    private FragmentManager fragmentManager;
-    private int containerId;
-
+public abstract class FragmentNavigator extends FragmentNavigatorBase<Fragment> {
     /**
      * Creates FragmentNavigator.
      *
@@ -36,118 +32,6 @@ public abstract class FragmentNavigator extends NavigatorBase {
      * @param containerId     id of the fragments container layout
      */
     public FragmentNavigator(FragmentManager fragmentManager, int containerId) {
-        this.fragmentManager = fragmentManager;
-        this.containerId = containerId;
+        super(new AndroidFragmentManagerAdapter(fragmentManager), containerId);
     }
-
-    /**
-     * Opens new screen based on the passed command.
-     *
-     * @param forward forward command to apply
-     */
-    @Override
-    protected void applyForward(Forward forward) {
-        Fragment fragment = createFragment(forward.getScreenKey(), forward.getTransitionData());
-        if (fragment == null) {
-            unknownScreen(forward);
-            return;
-        }
-        fragmentManager
-                .beginTransaction()
-                .replace(containerId, fragment)
-                .addToBackStack(forward.getScreenKey())
-                .commit();
-    }
-
-    /**
-     * Rolls back the last transition from the screens chain based on the passed command.
-     *
-     * @param back back command to apply
-     */
-    @Override
-    protected void applyBack(Back back) {
-        if (fragmentManager.getBackStackEntryCount() > 0) {
-            fragmentManager.popBackStackImmediate();
-        } else {
-            exit();
-        }
-    }
-
-    /**
-     * Replaces the current screen based on the passed command.
-     *
-     * @param replace replace command to apply
-     */
-    @Override
-    protected void applyReplace(Replace replace) {
-        Fragment fragment = createFragment(replace.getScreenKey(), replace.getTransitionData());
-        if (fragment == null) {
-            unknownScreen(replace);
-            return;
-        }
-        if (fragmentManager.getBackStackEntryCount() > 0) {
-            fragmentManager.popBackStackImmediate();
-            fragmentManager
-                    .beginTransaction()
-                    .replace(containerId, fragment)
-                    .addToBackStack(replace.getScreenKey())
-                    .commit();
-        } else {
-            fragmentManager
-                    .beginTransaction()
-                    .replace(containerId, fragment)
-                    .commit();
-        }
-    }
-
-    /**
-     * Rolls back to the needed screen from the screens chain based on the passed command.
-     *
-     * @param backTo backTo command to apply
-     */
-    @Override
-    protected void applyBackTo(BackTo backTo) {
-        String key = backTo.getScreenKey();
-
-        if (key == null) {
-            backToRoot();
-        } else {
-            boolean hasScreen = false;
-            for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
-                if (key.equals(fragmentManager.getBackStackEntryAt(i).getName())) {
-                    fragmentManager.popBackStackImmediate(key, 0);
-                    hasScreen = true;
-                    break;
-                }
-            }
-            if (!hasScreen) {
-                backToUnexisting();
-            }
-        }
-    }
-
-    private void backToRoot() {
-        for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
-            fragmentManager.popBackStack();
-        }
-        fragmentManager.executePendingTransactions();
-    }
-
-    /**
-     * Creates Fragment matching {@code screenKey}.
-     *
-     * @param screenKey screen key
-     * @param data      initialization data
-     * @return instantiated fragment for the passed screen key
-     */
-    protected abstract Fragment createFragment(String screenKey, Object data);
-
-    /**
-     * Called when we tried to back to some specific screen, but didn't found it.
-     */
-    @Override
-    protected void backToUnexisting() {
-        backToRoot();
-    }
-
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/FragmentNavigatorBase.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/FragmentNavigatorBase.java
@@ -1,0 +1,140 @@
+package ru.terrakok.cicerone.android;
+
+
+import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.android.adapters.FragmentManagerAdapter;
+import ru.terrakok.cicerone.commands.Back;
+import ru.terrakok.cicerone.commands.BackTo;
+import ru.terrakok.cicerone.commands.Forward;
+import ru.terrakok.cicerone.commands.Replace;
+
+/**
+ * {@link Navigator} implementation based on the fragments.
+ * <p>
+ * {@link BackTo} navigation command will return to the root if
+ * needed screen isn't found in the screens chain.
+ * To change this behavior override {@link #backToUnexisting()} method.
+ * </p>
+ * <p>
+ * {@link Back} command will call {@link #exit()} method if current screen is the root.
+ * </p>
+ */
+abstract class FragmentNavigatorBase<Fragment> extends NavigatorBase {
+    private final FragmentManagerAdapter<Fragment> fragmentManager;
+    private final int containerId;
+
+    protected FragmentNavigatorBase(FragmentManagerAdapter<Fragment> fragmentManager, int containerId) {
+        this.fragmentManager = fragmentManager;
+        this.containerId = containerId;
+    }
+
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
+    @Override
+    protected void applyForward(Forward forward) {
+        Fragment fragment = createFragment(forward.getScreenKey(), forward.getTransitionData());
+        if (fragment == null) {
+            unknownScreen(forward);
+            return;
+        }
+        fragmentManager
+                .beginTransaction()
+                .replace(containerId, fragment)
+                .addToBackStack(forward.getScreenKey())
+                .commit();
+    }
+
+    /**
+     * Rolls back the last transition from the screens chain based on the passed command.
+     *
+     * @param back back command to apply
+     */
+    @Override
+    protected void applyBack(Back back) {
+        if (fragmentManager.getBackStackEntryCount() > 0) {
+            fragmentManager.popBackStackImmediate();
+        } else {
+            exit();
+        }
+    }
+
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    @Override
+    protected void applyReplace(Replace replace) {
+        Fragment fragment = createFragment(replace.getScreenKey(), replace.getTransitionData());
+        if (fragment == null) {
+            unknownScreen(replace);
+            return;
+        }
+        if (fragmentManager.getBackStackEntryCount() > 0) {
+            fragmentManager.popBackStackImmediate();
+            fragmentManager
+                    .beginTransaction()
+                    .replace(containerId, fragment)
+                    .addToBackStack(replace.getScreenKey())
+                    .commit();
+        } else {
+            fragmentManager
+                    .beginTransaction()
+                    .replace(containerId, fragment)
+                    .commit();
+        }
+    }
+
+    /**
+     * Rolls back to the needed screen from the screens chain based on the passed command.
+     *
+     * @param backTo backTo command to apply
+     */
+    @Override
+    protected void applyBackTo(BackTo backTo) {
+        String key = backTo.getScreenKey();
+
+        if (key == null) {
+            backToRoot();
+        } else {
+            boolean hasScreen = false;
+            for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
+                if (key.equals(fragmentManager.getBackStackEntryAt(i).getName())) {
+                    fragmentManager.popBackStackImmediate(key, 0);
+                    hasScreen = true;
+                    break;
+                }
+            }
+            if (!hasScreen) {
+                backToUnexisting();
+            }
+        }
+    }
+
+    private void backToRoot() {
+        for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
+            fragmentManager.popBackStack();
+        }
+        fragmentManager.executePendingTransactions();
+    }
+
+    /**
+     * Creates Fragment matching {@code screenKey}.
+     *
+     * @param screenKey screen key
+     * @param data      initialization data
+     * @return instantiated fragment for the passed screen key
+     */
+    protected abstract Fragment createFragment(String screenKey, Object data);
+
+    /**
+     * Called when we tried to back to some specific screen, but didn't found it.
+     */
+    @Override
+    protected void backToUnexisting() {
+        backToRoot();
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/NavigatorBase.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/NavigatorBase.java
@@ -1,0 +1,91 @@
+package ru.terrakok.cicerone.android;
+
+
+import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.commands.Back;
+import ru.terrakok.cicerone.commands.BackTo;
+import ru.terrakok.cicerone.commands.Command;
+import ru.terrakok.cicerone.commands.Forward;
+import ru.terrakok.cicerone.commands.Replace;
+import ru.terrakok.cicerone.commands.SystemMessage;
+
+/**
+ * {@link Navigator} basic implementation with applyCommand dispatching.
+ * <p>
+ * (@Link #applyCommand(command)) method dispatches passed command to corresponding methods.
+ * </p>
+ */
+public abstract class NavigatorBase implements Navigator {
+
+    /**
+     * Performs transition described by the navigation command
+     *
+     * @param command the navigation command to apply
+     */
+    @Override
+    public void applyCommand(Command command) {
+        if (command instanceof Forward) {
+            applyForward((Forward) command);
+        } else if (command instanceof Back) {
+            applyBack((Back) command);
+        } else if (command instanceof Replace) {
+            applyReplace((Replace) command);
+        } else if (command instanceof BackTo) {
+            applyBackTo((BackTo) command);
+        } else if (command instanceof SystemMessage) {
+            showSystemMessage(((SystemMessage) command).getMessage());
+        }
+    }
+
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
+    protected abstract void applyForward(Forward forward);
+
+    /**
+     * Rolls back the last transition from the screens chain based on the passed command.
+     *
+     * @param back back command to apply
+     */
+    protected abstract void applyBack(Back back);
+
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    protected abstract void applyReplace(Replace replace);
+
+    /**
+     * Rolls back to the needed screen from the screens chain based on the passed command.
+     *
+     * @param backTo backTo command to apply
+     */
+    protected abstract void applyBackTo(BackTo backTo);
+
+    /**
+     * Shows system message.
+     *
+     * @param message message to show
+     */
+    protected abstract void showSystemMessage(String message);
+
+    /**
+     * Called when we try to back from the root.
+     */
+    protected abstract void exit();
+
+    /**
+     * Called when we tried to back to some specific screen, but didn't found it.
+     */
+    protected abstract void backToUnexisting();
+
+    /**
+     * Called if we can't create a screen.
+     */
+    protected void unknownScreen(Command command) {
+        throw new RuntimeException("Can't create a screen for passed screenKey.");
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
@@ -35,32 +35,37 @@ public abstract class SupportAppNavigator extends SupportFragmentNavigator {
         this.activity = activity;
     }
 
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
     @Override
-    public void applyCommand(Command command) {
-        if (command instanceof Forward) {
-            Forward forward = (Forward) command;
-            Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
+    protected void applyForward(Forward forward) {
+        Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
 
-            // Start activity
-            if (activityIntent != null) {
-                activity.startActivity(activityIntent);
-                return;
-            }
-
-        } else if (command instanceof Replace) {
-            Replace replace = (Replace) command;
-            Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
-
-            // Replace activity
-            if (activityIntent != null) {
-                activity.startActivity(activityIntent);
-                activity.finish();
-                return;
-            }
+        // Start activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            return;
         }
+    }
 
-        // Use default fragments navigation
-        super.applyCommand(command);
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    @Override
+    protected void applyReplace(Replace replace) {
+        Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
+
+        // Replace activity
+        if (activityIntent != null) {
+            activity.startActivity(activityIntent);
+            activity.finish();
+            return;
+        }
     }
 
     /**

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
@@ -3,6 +3,7 @@ package ru.terrakok.cicerone.android;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 
@@ -27,6 +28,16 @@ public abstract class SupportAppNavigator extends AppNavigatorBase {
     public SupportAppNavigator(FragmentActivity activity, @Deprecated FragmentManager fragmentManager, @Deprecated int containerId) {
         this(activity, containerId);
     }
+
+    /**
+     * Creates Fragment matching {@code screenKey}.
+     *
+     * @param screenKey screen key
+     * @param data      initialization data
+     * @return instantiated fragment for the passed screen key
+     */
+    @Deprecated
+    protected abstract Fragment createFragment(String screenKey, Object data);
 
     private static class SupportActivityAdapter implements ActivityAdapter {
         private final Activity activity;

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
@@ -1,19 +1,15 @@
 package ru.terrakok.cicerone.android;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
-import android.widget.Toast;
 
-import ru.terrakok.cicerone.commands.BackTo;
-import ru.terrakok.cicerone.commands.Command;
-import ru.terrakok.cicerone.commands.Forward;
-import ru.terrakok.cicerone.commands.Replace;
+import ru.terrakok.cicerone.android.adapters.ActivityAdapter;
 
 /**
- * Extends {@link SupportFragmentNavigator} to allow
- * open new or replace current activity.
+ * Allow open new or replace current activity.
  * <p>
  * This navigator DOESN'T provide full featured Activity navigation,
  * but can ease Activity start or replace from current navigator.
@@ -21,74 +17,37 @@ import ru.terrakok.cicerone.commands.Replace;
  *
  * @author Vasili Chyrvon (vasili.chyrvon@gmail.com)
  */
-public abstract class SupportAppNavigator extends SupportFragmentNavigator {
+public abstract class SupportAppNavigator extends AppNavigatorBase {
 
-    private Activity activity;
-
-    public SupportAppNavigator(FragmentActivity activity, int containerId) {
-        super(activity.getSupportFragmentManager(), containerId);
-        this.activity = activity;
+    public SupportAppNavigator(FragmentActivity activity, @Deprecated int containerId) {
+        super(new SupportActivityAdapter(activity));
     }
 
-    public SupportAppNavigator(FragmentActivity activity, FragmentManager fragmentManager, int containerId) {
-        super(fragmentManager, containerId);
-        this.activity = activity;
+    @Deprecated
+    public SupportAppNavigator(FragmentActivity activity, @Deprecated FragmentManager fragmentManager, @Deprecated int containerId) {
+        this(activity, containerId);
     }
 
-    /**
-     * Opens new screen based on the passed command.
-     *
-     * @param forward forward command to apply
-     */
-    @Override
-    protected void applyForward(Forward forward) {
-        Intent activityIntent = createActivityIntent(forward.getScreenKey(), forward.getTransitionData());
+    private static class SupportActivityAdapter implements ActivityAdapter {
+        private final Activity activity;
 
-        // Start activity
-        if (activityIntent != null) {
-            activity.startActivity(activityIntent);
-            return;
+        public SupportActivityAdapter(Activity activity) {
+            this.activity = activity;
         }
-    }
 
-    /**
-     * Replaces the current screen based on the passed command.
-     *
-     * @param replace replace command to apply
-     */
-    @Override
-    protected void applyReplace(Replace replace) {
-        Intent activityIntent = createActivityIntent(replace.getScreenKey(), replace.getTransitionData());
-
-        // Replace activity
-        if (activityIntent != null) {
+        @Override
+        public void startActivity(Intent activityIntent) {
             activity.startActivity(activityIntent);
+        }
+
+        @Override
+        public void finish() {
             activity.finish();
-            return;
         }
-    }
 
-    /**
-     * Creates Intent to start Activity for {@code screenKey}.
-     * <p>
-     * <b>Warning:</b> This method does not work with {@link BackTo} command.
-     * </p>
-     *
-     * @param screenKey screen key
-     * @param data      initialization data, can be null
-     * @return intent to start Activity for the passed screen key
-     */
-    protected abstract Intent createActivityIntent(String screenKey, Object data);
-
-    @Override
-    protected void showSystemMessage(String message) {
-        // Toast by default
-        Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    protected void exit() {
-        // Finish by default
-        activity.finish();
+        @Override
+        public Context getContext() {
+            return activity;
+        }
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportFragmentNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportFragmentNavigator.java
@@ -4,6 +4,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 
 import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.android.adapters.SupportFragmentManagerAdapter;
 import ru.terrakok.cicerone.commands.Back;
 import ru.terrakok.cicerone.commands.BackTo;
 import ru.terrakok.cicerone.commands.Forward;
@@ -25,10 +26,7 @@ import ru.terrakok.cicerone.commands.Replace;
  * {@link Back} command will call {@link #exit()} method if current screen is the root.
  * </p>
  */
-public abstract class SupportFragmentNavigator extends NavigatorBase {
-    private FragmentManager fragmentManager;
-    private int containerId;
-
+public abstract class SupportFragmentNavigator extends FragmentNavigatorBase<Fragment> {
     /**
      * Creates SupportFragmentNavigator.
      *
@@ -36,118 +34,7 @@ public abstract class SupportFragmentNavigator extends NavigatorBase {
      * @param containerId     id of the fragments container layout
      */
     public SupportFragmentNavigator(FragmentManager fragmentManager, int containerId) {
-        this.fragmentManager = fragmentManager;
-        this.containerId = containerId;
-    }
-
-    /**
-     * Opens new screen based on the passed command.
-     *
-     * @param forward forward command to apply
-     */
-    @Override
-    protected void applyForward(Forward forward) {
-        Fragment fragment = createFragment(forward.getScreenKey(), forward.getTransitionData());
-        if (fragment == null) {
-            unknownScreen(forward);
-            return;
-        }
-        fragmentManager
-                .beginTransaction()
-                .replace(containerId, fragment)
-                .addToBackStack(forward.getScreenKey())
-                .commit();
-    }
-
-    /**
-     * Rolls back the last transition from the screens chain based on the passed command.
-     *
-     * @param back back command to apply
-     */
-    @Override
-    protected void applyBack(Back back) {
-        if (fragmentManager.getBackStackEntryCount() > 0) {
-            fragmentManager.popBackStackImmediate();
-        } else {
-            exit();
-        }
-    }
-
-    /**
-     * Replaces the current screen based on the passed command.
-     *
-     * @param replace replace command to apply
-     */
-    @Override
-    protected void applyReplace(Replace replace) {
-        Fragment fragment = createFragment(replace.getScreenKey(), replace.getTransitionData());
-        if (fragment == null) {
-            unknownScreen(replace);
-            return;
-        }
-        if (fragmentManager.getBackStackEntryCount() > 0) {
-            fragmentManager.popBackStackImmediate();
-            fragmentManager
-                    .beginTransaction()
-                    .replace(containerId, fragment)
-                    .addToBackStack(replace.getScreenKey())
-                    .commit();
-        } else {
-            fragmentManager
-                    .beginTransaction()
-                    .replace(containerId, fragment)
-                    .commit();
-        }
-    }
-
-    /**
-     * Rolls back to the needed screen from the screens chain based on the passed command.
-     *
-     * @param backTo backTo command to apply
-     */
-    @Override
-    protected void applyBackTo(BackTo backTo) {
-        String key = backTo.getScreenKey();
-
-        if (key == null) {
-            backToRoot();
-        } else {
-            boolean hasScreen = false;
-            for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
-                if (key.equals(fragmentManager.getBackStackEntryAt(i).getName())) {
-                    fragmentManager.popBackStackImmediate(key, 0);
-                    hasScreen = true;
-                    break;
-                }
-            }
-            if (!hasScreen) {
-                backToUnexisting();
-            }
-        }
-    }
-
-    private void backToRoot() {
-        for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
-            fragmentManager.popBackStack();
-        }
-        fragmentManager.executePendingTransactions();
-    }
-
-    /**
-     * Creates Fragment matching {@code screenKey}.
-     *
-     * @param screenKey screen key
-     * @param data      initialization data
-     * @return instantiated fragment for the passed screen key
-     */
-    protected abstract Fragment createFragment(String screenKey, Object data);
-
-    /**
-     * Called when we tried to back to some specific screen, but didn't found it.
-     */
-    @Override
-    protected void backToUnexisting() {
-        backToRoot();
+        super(new SupportFragmentManagerAdapter(fragmentManager), containerId);
     }
 
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportFragmentNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportFragmentNavigator.java
@@ -6,10 +6,8 @@ import android.support.v4.app.FragmentManager;
 import ru.terrakok.cicerone.Navigator;
 import ru.terrakok.cicerone.commands.Back;
 import ru.terrakok.cicerone.commands.BackTo;
-import ru.terrakok.cicerone.commands.Command;
 import ru.terrakok.cicerone.commands.Forward;
 import ru.terrakok.cicerone.commands.Replace;
-import ru.terrakok.cicerone.commands.SystemMessage;
 
 /**
  * Created by Konstantin Tckhovrebov (aka @terrakok)
@@ -27,7 +25,7 @@ import ru.terrakok.cicerone.commands.SystemMessage;
  * {@link Back} command will call {@link #exit()} method if current screen is the root.
  * </p>
  */
-public abstract class SupportFragmentNavigator implements Navigator {
+public abstract class SupportFragmentNavigator extends NavigatorBase {
     private FragmentManager fragmentManager;
     private int containerId;
 
@@ -42,66 +40,89 @@ public abstract class SupportFragmentNavigator implements Navigator {
         this.containerId = containerId;
     }
 
+    /**
+     * Opens new screen based on the passed command.
+     *
+     * @param forward forward command to apply
+     */
     @Override
-    public void applyCommand(Command command) {
-        if (command instanceof Forward) {
-            Forward forward = (Forward) command;
-            Fragment fragment = createFragment(forward.getScreenKey(), forward.getTransitionData());
-            if (fragment == null) {
-                unknownScreen(command);
-                return;
-            }
+    protected void applyForward(Forward forward) {
+        Fragment fragment = createFragment(forward.getScreenKey(), forward.getTransitionData());
+        if (fragment == null) {
+            unknownScreen(forward);
+            return;
+        }
+        fragmentManager
+                .beginTransaction()
+                .replace(containerId, fragment)
+                .addToBackStack(forward.getScreenKey())
+                .commit();
+    }
+
+    /**
+     * Rolls back the last transition from the screens chain based on the passed command.
+     *
+     * @param back back command to apply
+     */
+    @Override
+    protected void applyBack(Back back) {
+        if (fragmentManager.getBackStackEntryCount() > 0) {
+            fragmentManager.popBackStackImmediate();
+        } else {
+            exit();
+        }
+    }
+
+    /**
+     * Replaces the current screen based on the passed command.
+     *
+     * @param replace replace command to apply
+     */
+    @Override
+    protected void applyReplace(Replace replace) {
+        Fragment fragment = createFragment(replace.getScreenKey(), replace.getTransitionData());
+        if (fragment == null) {
+            unknownScreen(replace);
+            return;
+        }
+        if (fragmentManager.getBackStackEntryCount() > 0) {
+            fragmentManager.popBackStackImmediate();
             fragmentManager
                     .beginTransaction()
                     .replace(containerId, fragment)
-                    .addToBackStack(forward.getScreenKey())
+                    .addToBackStack(replace.getScreenKey())
                     .commit();
-        } else if (command instanceof Back) {
-            if (fragmentManager.getBackStackEntryCount() > 0) {
-                fragmentManager.popBackStackImmediate();
-            } else {
-                exit();
-            }
-        } else if (command instanceof Replace) {
-            Replace replace = (Replace) command;
-            Fragment fragment = createFragment(replace.getScreenKey(), replace.getTransitionData());
-            if (fragment == null) {
-                unknownScreen(command);
-                return;
-            }
-            if (fragmentManager.getBackStackEntryCount() > 0) {
-                fragmentManager.popBackStackImmediate();
-                fragmentManager
-                        .beginTransaction()
-                        .replace(containerId, fragment)
-                        .addToBackStack(replace.getScreenKey())
-                        .commit();
-            } else {
-                fragmentManager
-                        .beginTransaction()
-                        .replace(containerId, fragment)
-                        .commit();
-            }
-        } else if (command instanceof BackTo) {
-            String key = ((BackTo) command).getScreenKey();
+        } else {
+            fragmentManager
+                    .beginTransaction()
+                    .replace(containerId, fragment)
+                    .commit();
+        }
+    }
 
-            if (key == null) {
-                backToRoot();
-            } else {
-                boolean hasScreen = false;
-                for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
-                    if (key.equals(fragmentManager.getBackStackEntryAt(i).getName())) {
-                        fragmentManager.popBackStackImmediate(key, 0);
-                        hasScreen = true;
-                        break;
-                    }
-                }
-                if (!hasScreen) {
-                    backToUnexisting();
+    /**
+     * Rolls back to the needed screen from the screens chain based on the passed command.
+     *
+     * @param backTo backTo command to apply
+     */
+    @Override
+    protected void applyBackTo(BackTo backTo) {
+        String key = backTo.getScreenKey();
+
+        if (key == null) {
+            backToRoot();
+        } else {
+            boolean hasScreen = false;
+            for (int i = 0; i < fragmentManager.getBackStackEntryCount(); i++) {
+                if (key.equals(fragmentManager.getBackStackEntryAt(i).getName())) {
+                    fragmentManager.popBackStackImmediate(key, 0);
+                    hasScreen = true;
+                    break;
                 }
             }
-        } else if (command instanceof SystemMessage) {
-            showSystemMessage(((SystemMessage) command).getMessage());
+            if (!hasScreen) {
+                backToUnexisting();
+            }
         }
     }
 
@@ -122,28 +143,11 @@ public abstract class SupportFragmentNavigator implements Navigator {
     protected abstract Fragment createFragment(String screenKey, Object data);
 
     /**
-     * Shows system message.
-     *
-     * @param message message to show
-     */
-    protected abstract void showSystemMessage(String message);
-
-    /**
-     * Called when we try to back from the root.
-     */
-    protected abstract void exit();
-
-    /**
      * Called when we tried to back to some specific screen, but didn't found it.
      */
+    @Override
     protected void backToUnexisting() {
         backToRoot();
     }
 
-    /**
-     * Called if we can't create a screen.
-     */
-    protected void unknownScreen(Command command) {
-        throw new RuntimeException("Can't create a screen for passed screenKey.");
-    }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/ActivityAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/ActivityAdapter.java
@@ -1,0 +1,13 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+import android.content.Context;
+import android.content.Intent;
+
+public interface ActivityAdapter {
+    void startActivity(Intent activityIntent);
+
+    void finish();
+
+    Context getContext();
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/AndroidFragmentManagerAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/AndroidFragmentManagerAdapter.java
@@ -1,0 +1,95 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+
+public class AndroidFragmentManagerAdapter implements FragmentManagerAdapter<Fragment> {
+    private final FragmentManager fragmentManager;
+
+    public AndroidFragmentManagerAdapter(FragmentManager fragmentManager) {
+        this.fragmentManager = fragmentManager;
+    }
+
+    @Override
+    public FragmentTransactionAdapter<Fragment> beginTransaction() {
+        return new AndroidFragmentTransactionAdapter(fragmentManager.beginTransaction());
+    }
+
+    @Override
+    public boolean executePendingTransactions() {
+        return fragmentManager.executePendingTransactions();
+    }
+
+    @Override
+    public void popBackStack() {
+        fragmentManager.popBackStack();
+    }
+
+    @Override
+    public boolean popBackStackImmediate() {
+        return fragmentManager.popBackStackImmediate();
+    }
+
+    @Override
+    public boolean popBackStackImmediate(String name, int flags) {
+        return fragmentManager.popBackStackImmediate(name, flags);
+    }
+
+    @Override
+    public int getBackStackEntryCount() {
+        return fragmentManager.getBackStackEntryCount();
+    }
+
+    @Override
+    public BackStackEntryAdapter getBackStackEntryAt(int index) {
+        FragmentManager.BackStackEntry backStackEntry = fragmentManager.getBackStackEntryAt(index);
+        return new AndroidBackStackEntryAdapter(backStackEntry);
+    }
+
+
+    private static class AndroidBackStackEntryAdapter implements BackStackEntryAdapter {
+        private final FragmentManager.BackStackEntry backStackEntry;
+
+        public AndroidBackStackEntryAdapter(FragmentManager.BackStackEntry backStackEntry) {
+            this.backStackEntry = backStackEntry;
+        }
+
+        @Override
+        public int getId() {
+            return backStackEntry.getId();
+        }
+
+        @Override
+        public String getName() {
+            return backStackEntry.getName();
+        }
+    }
+
+
+    private static class AndroidFragmentTransactionAdapter implements FragmentTransactionAdapter<Fragment> {
+        private final FragmentTransaction transaction;
+
+        public AndroidFragmentTransactionAdapter(FragmentTransaction transaction) {
+            this.transaction = transaction;
+        }
+
+        @Override
+        public FragmentTransactionAdapter replace(int containerViewId, Fragment fragment) {
+            transaction.replace(containerViewId, fragment);
+            return this;
+        }
+
+        @Override
+        public FragmentTransactionAdapter addToBackStack(String name) {
+            transaction.addToBackStack(name);
+            return this;
+        }
+
+        @Override
+        public int commit() {
+            return transaction.commit();
+        }
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentAdapter.java
@@ -1,0 +1,14 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+public class FragmentAdapter <Fragment> {
+    private final Fragment fragment;
+
+    public FragmentAdapter(Fragment fragment) {
+        this.fragment = fragment;
+    }
+
+    Fragment getFragment() {
+        return fragment;
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentManagerAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentManagerAdapter.java
@@ -1,0 +1,26 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+public interface FragmentManagerAdapter <Fragment> {
+
+    FragmentTransactionAdapter<Fragment> beginTransaction();
+
+    boolean executePendingTransactions();
+
+    void popBackStack();
+
+    boolean popBackStackImmediate();
+
+    boolean popBackStackImmediate(String name, int flags);
+
+    int getBackStackEntryCount();
+
+    BackStackEntryAdapter getBackStackEntryAt(int index);
+
+
+    interface BackStackEntryAdapter {
+        int getId();
+
+        String getName();
+    }
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentTransactionAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/FragmentTransactionAdapter.java
@@ -1,0 +1,10 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+public interface FragmentTransactionAdapter <Fragment> {
+    FragmentTransactionAdapter replace(int containerViewId, Fragment fragment);
+
+    FragmentTransactionAdapter addToBackStack(String name);
+
+    int commit();
+}

--- a/library/src/main/java/ru/terrakok/cicerone/android/adapters/SupportFragmentManagerAdapter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/adapters/SupportFragmentManagerAdapter.java
@@ -1,0 +1,94 @@
+package ru.terrakok.cicerone.android.adapters;
+
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
+
+public class SupportFragmentManagerAdapter implements FragmentManagerAdapter<Fragment> {
+    private final FragmentManager fragmentManager;
+
+    public SupportFragmentManagerAdapter(FragmentManager fragmentManager) {
+        this.fragmentManager = fragmentManager;
+    }
+
+    @Override
+    public FragmentTransactionAdapter<Fragment> beginTransaction() {
+        return new SupportFragmentTransactionAdapter(fragmentManager.beginTransaction());
+    }
+
+    @Override
+    public boolean executePendingTransactions() {
+        return fragmentManager.executePendingTransactions();
+    }
+
+    @Override
+    public void popBackStack() {
+        fragmentManager.popBackStack();
+    }
+
+    @Override
+    public boolean popBackStackImmediate() {
+        return fragmentManager.popBackStackImmediate();
+    }
+
+    @Override
+    public boolean popBackStackImmediate(String name, int flags) {
+        return fragmentManager.popBackStackImmediate(name, flags);
+    }
+
+    @Override
+    public int getBackStackEntryCount() {
+        return fragmentManager.getBackStackEntryCount();
+    }
+
+    @Override
+    public BackStackEntryAdapter getBackStackEntryAt(int index) {
+        FragmentManager.BackStackEntry backStackEntry = fragmentManager.getBackStackEntryAt(index);
+        return new SupportBackStackEntryAdapter(backStackEntry);
+    }
+
+    private static class SupportBackStackEntryAdapter implements BackStackEntryAdapter {
+        private final FragmentManager.BackStackEntry backStackEntry;
+
+        public SupportBackStackEntryAdapter(FragmentManager.BackStackEntry backStackEntry) {
+            this.backStackEntry = backStackEntry;
+        }
+
+        @Override
+        public int getId() {
+            return backStackEntry.getId();
+        }
+
+        @Override
+        public String getName() {
+            return backStackEntry.getName();
+        }
+    }
+
+    private static class SupportFragmentTransactionAdapter implements FragmentTransactionAdapter<Fragment> {
+
+        private final FragmentTransaction transaction;
+
+        public SupportFragmentTransactionAdapter(FragmentTransaction transaction) {
+            this.transaction = transaction;
+        }
+
+        @Override
+        public FragmentTransactionAdapter replace(int containerViewId, Fragment fragment) {
+            transaction.replace(containerViewId, fragment);
+            return this;
+        }
+
+        @Override
+        public FragmentTransactionAdapter addToBackStack(String name) {
+            transaction.addToBackStack(name);
+            return this;
+        }
+
+        @Override
+        public int commit() {
+            return transaction.commit();
+        }
+    }
+}


### PR DESCRIPTION
1. Extracting base navigation logic for Navigators.
Using template method and adapter pattern. Now instead of override all command processing logic inheritors available to pointwise override only part of command processing that needs. Moving lot of boilerplate code from main navigation logic.
2. Removing AppNavigators inheritance from FragmentNavigators. Was look strange that instead of implements own navigation logic for activity navigation there was extending fragment navigation.