### PR TITLE
Added check for the activity existence before opening.

### DIFF
--- a/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/AppNavigator.java
@@ -55,7 +55,7 @@ public abstract class AppNavigator extends FragmentNavigator {
             // Start activity
             if (activityIntent != null) {
                 Bundle options = createStartActivityOptions(command, activityIntent);
-                activity.startActivity(activityIntent, options);
+                checkAndStartActivity(forward.getScreenKey(), activityIntent, options);
                 return;
             }
 
@@ -66,7 +66,7 @@ public abstract class AppNavigator extends FragmentNavigator {
             // Replace activity
             if (activityIntent != null) {
                 Bundle options = createStartActivityOptions(command, activityIntent);
-                activity.startActivity(activityIntent, options);
+                checkAndStartActivity(replace.getScreenKey(), activityIntent, options);
                 activity.finish();
                 return;
             }
@@ -74,6 +74,25 @@ public abstract class AppNavigator extends FragmentNavigator {
 
         // Use default fragments navigation
         super.applyCommand(command);
+    }
+
+    private void checkAndStartActivity(String screenKey, Intent activityIntent, Bundle options) {
+        // Check if we can start activity
+        if (activityIntent.resolveActivity(activity.getPackageManager()) != null) {
+            activity.startActivity(activityIntent, options);
+        } else {
+            unexistingActivity(screenKey, activityIntent);
+        }
+    }
+
+    /**
+     * Called when there is no activity to open {@code screenKey}.
+     *
+     * @param screenKey screen key
+     * @param activityIntent intent passed to start Activity for the {@code screenKey}
+     */
+    protected void unexistingActivity(String screenKey, Intent activityIntent) {
+        // Do nothing by default
     }
 
     /**

--- a/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/SupportAppNavigator.java
@@ -56,7 +56,7 @@ public abstract class SupportAppNavigator extends SupportFragmentNavigator {
             // Start activity
             if (activityIntent != null) {
                 Bundle options = createStartActivityOptions(command, activityIntent);
-                activity.startActivity(activityIntent, options);
+                checkAndStartActivity(forward.getScreenKey(), activityIntent, options);
                 return;
             }
 
@@ -67,7 +67,7 @@ public abstract class SupportAppNavigator extends SupportFragmentNavigator {
             // Replace activity
             if (activityIntent != null) {
                 Bundle options = createStartActivityOptions(command, activityIntent);
-                activity.startActivity(activityIntent, options);
+                checkAndStartActivity(replace.getScreenKey(), activityIntent, options);
                 activity.finish();
                 return;
             }
@@ -75,6 +75,25 @@ public abstract class SupportAppNavigator extends SupportFragmentNavigator {
 
         // Use default fragments navigation
         super.applyCommand(command);
+    }
+
+    private void checkAndStartActivity(String screenKey, Intent activityIntent, Bundle options) {
+        // Check if we can start activity
+        if (activityIntent.resolveActivity(activity.getPackageManager()) != null) {
+            activity.startActivity(activityIntent, options);
+        } else {
+            unexistingActivity(screenKey, activityIntent);
+        }
+    }
+
+    /**
+     * Called when there is no activity to open {@code screenKey}.
+     *
+     * @param screenKey screen key
+     * @param activityIntent intent passed to start Activity for the {@code screenKey}
+     */
+    protected void unexistingActivity(String screenKey, Intent activityIntent) {
+        // Do nothing by default
     }
 
     /**

--- a/library/stub-android/src/main/java/android/content/ComponentName.java
+++ b/library/stub-android/src/main/java/android/content/ComponentName.java
@@ -1,0 +1,5 @@
+package android.content;
+
+
+public class ComponentName {
+}

--- a/library/stub-android/src/main/java/android/content/Context.java
+++ b/library/stub-android/src/main/java/android/content/Context.java
@@ -1,8 +1,11 @@
 package android.content;
 
+import android.content.pm.PackageManager;
+
 /**
  * @author Konstantin Tskhovrebov (aka terrakok). Date: 10.03.17
  */
 
 public class Context {
+    public PackageManager getPackageManager() { throw new RuntimeException("Stub!"); }
 }

--- a/library/stub-android/src/main/java/android/content/Intent.java
+++ b/library/stub-android/src/main/java/android/content/Intent.java
@@ -1,9 +1,12 @@
 package android.content;
 
+import android.content.pm.PackageManager;
+
 /**
  * Created by Konstantin Tckhovrebov (aka @terrakok)
  * on 22.02.17
  */
 
 public class Intent {
+    public ComponentName resolveActivity(PackageManager pm) { throw new RuntimeException("Stub!"); }
 }

--- a/library/stub-android/src/main/java/android/content/pm/PackageManager.java
+++ b/library/stub-android/src/main/java/android/content/pm/PackageManager.java
@@ -1,0 +1,5 @@
+package android.content.pm;
+
+
+public class PackageManager {
+}


### PR DESCRIPTION
Realised that we don't check if the system has Activity that can handle created Intent (eg. no dialer on the tablet). And there is no way to deal with it from outside the library (if we check intent and return null, then the lib will try to create fragment and will fail with the exception).