### PR TITLE
Fix error in Router.java

### DIFF
--- a/library/src/main/java/ru/terrakok/cicerone/Router.java
+++ b/library/src/main/java/ru/terrakok/cicerone/Router.java
@@ -87,7 +87,7 @@ public class Router extends BaseRouter {
         commands[0] = new BackTo(null);
         if (screens.length > 0) {
             commands[1] = new Replace(screens[0]);
-            for (int i = 1; i < commands.length; i++) {
+            for (int i = 1; i < screens.length; i++) {
                 commands[i + 1] = new Forward(screens[i]);
             }
         }


### PR DESCRIPTION
I make call:
`router.newRootChain(new ScreenOne(), new ScreenTwo());`
and get a exception 
```
java.lang.ArrayIndexOutOfBoundsException: length=2; index=2
at ru.terrakok.cicerone.Router.newRootChain(Router.java:91)
at ...
```
I suppose, iteration bound must be equal to length of array `screens` (not `commands`).