### PR TITLE
Add android architecture component navigator

### DIFF
--- a/aac_navigation/.gitignore
+++ b/aac_navigation/.gitignore
@@ -1,0 +1,2 @@
+/build
+/libs

--- a/aac_navigation/build.gradle
+++ b/aac_navigation/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'com.android.library'
+
+// This is important even if Android Studio claims it isn't
+// used. Android can't interpret Java 8 byte code.
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 14
+        targetSdkVersion 28
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+        debug {}
+    }
+
+}
+
+dependencies {
+    //Cicerone
+    implementation project(':library')
+
+    implementation 'android.arch.navigation:navigation-fragment:1.0.0-alpha06'
+}

--- a/aac_navigation/build.gradle
+++ b/aac_navigation/build.gradle
@@ -28,5 +28,5 @@ dependencies {
     //Cicerone
     implementation project(':library')
 
-    implementation 'android.arch.navigation:navigation-fragment:1.0.0-alpha06'
+    api 'android.arch.navigation:navigation-fragment:1.0.0-alpha06'
 }

--- a/aac_navigation/src/main/AndroidManifest.xml
+++ b/aac_navigation/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="ru.terrakok.cicerone" />

--- a/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
+++ b/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
@@ -1,0 +1,81 @@
+package ru.terrakok.cicerone.android.aac;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
+import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.Screen;
+import ru.terrakok.cicerone.commands.Back;
+import ru.terrakok.cicerone.commands.BackTo;
+import ru.terrakok.cicerone.commands.Command;
+import ru.terrakok.cicerone.commands.Forward;
+import ru.terrakok.cicerone.commands.Replace;
+
+public class AacNavigator implements Navigator {
+
+    private final NavController navController;
+    private final FragmentActivity activity;
+
+    public AacNavigator(FragmentActivity activity, int navFragmentId) {
+        this.activity = activity;
+        Fragment navFrag = activity.getSupportFragmentManager().findFragmentById(navFragmentId);
+        if (navFrag instanceof NavHostFragment) {
+            navController = ((NavHostFragment) navFrag).getNavController();
+        } else {
+            throw new IllegalArgumentException("No NavHostFragment found at given FragmentActivity." +
+                    " Please make sure you don't forget to add it!");
+        }
+    }
+
+    @Override
+    public void applyCommands(Command[] commands) {
+        for (Command command : commands) {
+            applyCommand(command);
+        }
+    }
+
+    protected void applyCommand(Command command) {
+        if (command instanceof Forward) {
+            fragmentForward(((Forward) command).getScreen());
+        } else if (command instanceof Replace) {
+            fragmentReplace(((Replace) command).getScreen());
+        } else if (command instanceof BackTo) {
+            fragmentBackTo(((BackTo) command).getScreen());
+        } else if (command instanceof Back) {
+            fragmentBack();
+        }
+    }
+
+    private void fragmentReplace(Screen screen) {
+        fragmentBack();
+        fragmentForward(screen);
+    }
+
+    private void fragmentForward(Screen screen) {
+        AacScreen aacScreen = checkScreenInstance(screen);
+        navController.navigate(aacScreen.getNavigationResId(),
+                aacScreen.getArgs(),
+                aacScreen.getNavOptions(), aacScreen.getNavExtras());
+    }
+
+    private void fragmentBack() {
+        // if we haven't popped fragment it means that no fragments left and we have to finish an activity
+        if (!navController.popBackStack()) {
+            activity.finish();
+        }
+    }
+
+    private void fragmentBackTo(Screen screen) {
+        AacScreen aacScreen = checkScreenInstance(screen);
+        navController.popBackStack(aacScreen.getNavigationResId(), false);
+    }
+
+    private AacScreen checkScreenInstance(Screen screen) {
+        if (screen instanceof AacScreen) {
+            return (AacScreen) screen;
+        }
+        throw new IllegalArgumentException("Screen should be instance of AacScreen!");
+    }
+}

--- a/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
+++ b/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
@@ -36,7 +36,11 @@ public class AacNavigator implements Navigator {
         }
     }
 
-    protected void applyCommand(Command command) {
+    protected void finishActivity() {
+        activity.finish();
+    }
+
+    private void applyCommand(Command command) {
         if (command instanceof Forward) {
             fragmentForward(((Forward) command).getScreen());
         } else if (command instanceof Replace) {
@@ -55,15 +59,17 @@ public class AacNavigator implements Navigator {
 
     private void fragmentForward(Screen screen) {
         AacScreen aacScreen = checkScreenInstance(screen);
-        navController.navigate(aacScreen.getNavigationResId(),
+        navController.navigate(
+                aacScreen.getNavigationResId(),
                 aacScreen.getArgs(),
-                aacScreen.getNavOptions(), aacScreen.getNavExtras());
+                aacScreen.getNavOptions(),
+                aacScreen.getNavExtras());
     }
 
     private void fragmentBack() {
         // if we haven't popped fragment it means that no fragments left and we have to finish an activity
         if (!navController.popBackStack()) {
-            activity.finish();
+            finishActivity();
         }
     }
 

--- a/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
+++ b/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacNavigator.java
@@ -53,7 +53,7 @@ public class AacNavigator implements Navigator {
     }
 
     private void fragmentReplace(Screen screen) {
-        fragmentBack();
+        navController.popBackStack();
         fragmentForward(screen);
     }
 

--- a/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacScreen.java
+++ b/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacScreen.java
@@ -1,0 +1,29 @@
+package ru.terrakok.cicerone.android.aac;
+
+import android.os.Bundle;
+import android.support.annotation.IdRes;
+
+import androidx.navigation.NavOptions;
+import androidx.navigation.Navigator;
+import ru.terrakok.cicerone.Screen;
+
+public abstract class AacScreen extends Screen {
+
+    /*
+    It could be actionId or destinationId
+     */
+    @IdRes
+    public abstract int getNavigationResId();
+
+    public Bundle getArgs() {
+        return null;
+    }
+
+    public NavOptions getNavOptions() {
+        return null;
+    }
+
+    public Navigator.Extras getNavExtras() {
+        return null;
+    }
+}

--- a/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacScreen.java
+++ b/aac_navigation/src/main/java/ru/terrakok/cicerone/android/aac/AacScreen.java
@@ -9,8 +9,8 @@ import ru.terrakok.cicerone.Screen;
 
 public abstract class AacScreen extends Screen {
 
-    /*
-    It could be actionId or destinationId
+    /**
+     * It could be actionId or destinationId
      */
     @IdRes
     public abstract int getNavigationResId();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -40,8 +40,6 @@ dependencies {
     //MVP Moxy
     implementation "com.arello-mobile:moxy:$moxyVersion"
     implementation "com.arello-mobile:moxy-app-compat:$moxyVersion"
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.google.android.gms:play-services-plus:16.0.0'
     annotationProcessor "com.arello-mobile:moxy-compiler:$moxyVersion"
 
     //Cicerone

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,11 +5,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0.0"
         applicationId "ru.terrakok.cicerone.sample"
@@ -27,7 +27,7 @@ android {
 }
 
 ext {
-    supportLibraryVersion = "25.3.0"
+    supportLibraryVersion = "28.0.0"
     moxyVersion = "1.4.6"
     daggerVersion = "2.10"
 }
@@ -40,17 +40,20 @@ dependencies {
     //MVP Moxy
     implementation "com.arello-mobile:moxy:$moxyVersion"
     implementation "com.arello-mobile:moxy-app-compat:$moxyVersion"
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.google.android.gms:play-services-plus:16.0.0'
     annotationProcessor "com.arello-mobile:moxy-compiler:$moxyVersion"
 
     //Cicerone
     implementation project(':library')
+    implementation project(':aac_navigation')
 
     //DI
     implementation "com.google.dagger:dagger:$daggerVersion"
     annotationProcessor "com.google.dagger:dagger-compiler:$daggerVersion"
 
     //Bottom Navigation Bar
-    implementation ('com.ashokvarma.android:bottom-navigation-bar:1.3.0') {
+    implementation('com.ashokvarma.android:bottom-navigation-bar:1.3.0') {
         exclude group: "com.android.support", module: "design"
     }
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         <activity android:name=".ui.start.StartActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ru.terrakok.cicerone.sample">
+<manifest
+    package="ru.terrakok.cicerone.sample"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".SampleApplication"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    package="ru.terrakok.cicerone.sample"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="ru.terrakok.cicerone.sample">
 
     <application
         android:name=".SampleApplication"
@@ -9,17 +8,17 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
-
-        <activity
-            android:name=".ui.start.StartActivity">
+        <activity android:name=".ui.start.StartActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity android:name=".ui.main.MainActivity"/>
-        <activity android:name=".ui.bottom.BottomNavigationActivity"/>
-        <activity android:name=".ui.animations.ProfileActivity"/>
+        <activity android:name=".ui.main.MainActivity" />
+        <activity android:name=".ui.bottom.BottomNavigationActivity" />
+        <activity android:name=".ui.animations.ProfileActivity" />
+        <activity android:name=".ui.aac.AacActivity" />
     </application>
+
 </manifest>

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/AacScreens.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/AacScreens.java
@@ -1,0 +1,43 @@
+package ru.terrakok.cicerone.sample;
+
+import android.content.Context;
+import android.content.Intent;
+
+import ru.terrakok.cicerone.android.aac.AacScreen;
+import ru.terrakok.cicerone.android.support.SupportAppScreen;
+import ru.terrakok.cicerone.sample.ui.aac.AacActivity;
+
+final public class AacScreens {
+
+    public static final class AacScreenFlow extends SupportAppScreen {
+
+        @Override
+        public Intent getActivityIntent(Context context) {
+            return new Intent(context, AacActivity.class);
+        }
+    }
+
+    public static final class AacBlankSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_blank;
+        }
+    }
+
+    public static final class AacFirstSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_first;
+        }
+    }
+
+    public static final class AacSecondSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_second;
+        }
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/Screens.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/Screens.java
@@ -114,36 +114,4 @@ public class Screens {
             return new SelectPhotoFragment();
         }
     }
-
-    public static final class AacScreenFlow extends SupportAppScreen {
-
-        @Override
-        public Intent getActivityIntent(Context context) {
-            return new Intent(context, AacActivity.class);
-        }
-    }
-
-    public static final class AacBlankSampleScreen extends AacScreen {
-
-        @Override
-        public int getNavigationResId() {
-            return R.id.next_action_aac_blank;
-        }
-    }
-
-    public static final class AacFirstSampleScreen extends AacScreen {
-
-        @Override
-        public int getNavigationResId() {
-            return R.id.next_action_aac_first;
-        }
-    }
-
-    public static final class AacSecondSampleScreen extends AacScreen {
-
-        @Override
-        public int getNavigationResId() {
-            return R.id.next_action_aac_second;
-        }
-    }
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/Screens.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/Screens.java
@@ -5,7 +5,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.v4.app.Fragment;
 
+import ru.terrakok.cicerone.android.aac.AacScreen;
 import ru.terrakok.cicerone.android.support.SupportAppScreen;
+import ru.terrakok.cicerone.sample.ui.aac.AacActivity;
 import ru.terrakok.cicerone.sample.ui.animations.ProfileActivity;
 import ru.terrakok.cicerone.sample.ui.animations.photos.SelectPhotoFragment;
 import ru.terrakok.cicerone.sample.ui.animations.profile.ProfileFragment;
@@ -110,6 +112,38 @@ public class Screens {
         @Override
         public Fragment getFragment() {
             return new SelectPhotoFragment();
+        }
+    }
+
+    public static final class AacScreenFlow extends SupportAppScreen {
+
+        @Override
+        public Intent getActivityIntent(Context context) {
+            return new Intent(context, AacActivity.class);
+        }
+    }
+
+    public static final class AacBlankSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_blank;
+        }
+    }
+
+    public static final class AacFirstSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_first;
+        }
+    }
+
+    public static final class AacSecondSampleScreen extends AacScreen {
+
+        @Override
+        public int getNavigationResId() {
+            return R.id.next_action_aac_second;
         }
     }
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/dagger/AppComponent.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/dagger/AppComponent.java
@@ -6,6 +6,10 @@ import dagger.Component;
 import ru.terrakok.cicerone.sample.dagger.module.LocalNavigationModule;
 import ru.terrakok.cicerone.sample.dagger.module.NavigationModule;
 import ru.terrakok.cicerone.sample.dagger.module.PhotoSelectionModule;
+import ru.terrakok.cicerone.sample.ui.aac.AacActivity;
+import ru.terrakok.cicerone.sample.ui.aac.AacBlankFragment;
+import ru.terrakok.cicerone.sample.ui.aac.AacFirstSampleFragment;
+import ru.terrakok.cicerone.sample.ui.aac.AacSecondSampleFragment;
 import ru.terrakok.cicerone.sample.ui.animations.ProfileActivity;
 import ru.terrakok.cicerone.sample.ui.animations.photos.SelectPhotoFragment;
 import ru.terrakok.cicerone.sample.ui.animations.profile.ProfileFragment;
@@ -42,4 +46,12 @@ public interface AppComponent {
     void inject(SelectPhotoFragment fragment);
 
     void inject(ProfileActivity activity);
+
+    void inject(AacActivity activity);
+
+    void inject(AacBlankFragment fragment);
+
+    void inject(AacFirstSampleFragment fragment);
+
+    void inject(AacSecondSampleFragment fragment);
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankPresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankPresenter.java
@@ -1,0 +1,20 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.InjectViewState;
+import com.arellomobile.mvp.MvpPresenter;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.Screens;
+
+@InjectViewState
+public class AacBlankPresenter extends MvpPresenter<AacBlankView> {
+    private final Router router;
+
+    public AacBlankPresenter(Router router) {
+        this.router = router;
+    }
+
+    public void onAacFirstPressed() {
+        router.navigateTo(new Screens.AacFirstSampleScreen());
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankPresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankPresenter.java
@@ -1,13 +1,12 @@
 package ru.terrakok.cicerone.sample.mvp.aac;
 
-import com.arellomobile.mvp.InjectViewState;
 import com.arellomobile.mvp.MvpPresenter;
+import com.arellomobile.mvp.MvpView;
 
 import ru.terrakok.cicerone.Router;
-import ru.terrakok.cicerone.sample.Screens;
+import ru.terrakok.cicerone.sample.AacScreens;
 
-@InjectViewState
-public class AacBlankPresenter extends MvpPresenter<AacBlankView> {
+public class AacBlankPresenter extends MvpPresenter<MvpView> {
     private final Router router;
 
     public AacBlankPresenter(Router router) {
@@ -15,6 +14,6 @@ public class AacBlankPresenter extends MvpPresenter<AacBlankView> {
     }
 
     public void onAacFirstPressed() {
-        router.navigateTo(new Screens.AacFirstSampleScreen());
+        router.navigateTo(new AacScreens.AacFirstSampleScreen());
     }
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankView.java
@@ -1,0 +1,6 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.MvpView;
+
+public interface AacBlankView extends MvpView {
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacBlankView.java
@@ -1,6 +1,0 @@
-package ru.terrakok.cicerone.sample.mvp.aac;
-
-import com.arellomobile.mvp.MvpView;
-
-public interface AacBlankView extends MvpView {
-}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSamplePresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSamplePresenter.java
@@ -1,0 +1,19 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.MvpPresenter;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.Screens;
+
+public class AacFirstSamplePresenter extends MvpPresenter<AacFirstSampleView> {
+
+    private final Router router;
+
+    public AacFirstSamplePresenter(Router router) {
+        this.router = router;
+    }
+
+    public void onAacSecondPressed() {
+        router.navigateTo(new Screens.AacSecondSampleScreen());
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSamplePresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSamplePresenter.java
@@ -1,11 +1,12 @@
 package ru.terrakok.cicerone.sample.mvp.aac;
 
 import com.arellomobile.mvp.MvpPresenter;
+import com.arellomobile.mvp.MvpView;
 
 import ru.terrakok.cicerone.Router;
-import ru.terrakok.cicerone.sample.Screens;
+import ru.terrakok.cicerone.sample.AacScreens;
 
-public class AacFirstSamplePresenter extends MvpPresenter<AacFirstSampleView> {
+public class AacFirstSamplePresenter extends MvpPresenter<MvpView> {
 
     private final Router router;
 
@@ -14,6 +15,6 @@ public class AacFirstSamplePresenter extends MvpPresenter<AacFirstSampleView> {
     }
 
     public void onAacSecondPressed() {
-        router.navigateTo(new Screens.AacSecondSampleScreen());
+        router.navigateTo(new AacScreens.AacSecondSampleScreen());
     }
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSampleView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSampleView.java
@@ -1,6 +1,0 @@
-package ru.terrakok.cicerone.sample.mvp.aac;
-
-import com.arellomobile.mvp.MvpView;
-
-public interface AacFirstSampleView extends MvpView {
-}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSampleView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacFirstSampleView.java
@@ -1,0 +1,6 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.MvpView;
+
+public interface AacFirstSampleView extends MvpView {
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSamplePresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSamplePresenter.java
@@ -1,0 +1,19 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.MvpPresenter;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.Screens;
+
+public class AacSecondSamplePresenter extends MvpPresenter<AacSecondSampleView> {
+
+    private final Router router;
+
+    public AacSecondSamplePresenter(Router router) {
+        this.router = router;
+    }
+
+    public void onAacBlankPressed() {
+        router.navigateTo(new Screens.AacBlankSampleScreen());
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSamplePresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSamplePresenter.java
@@ -1,11 +1,12 @@
 package ru.terrakok.cicerone.sample.mvp.aac;
 
 import com.arellomobile.mvp.MvpPresenter;
+import com.arellomobile.mvp.MvpView;
 
 import ru.terrakok.cicerone.Router;
-import ru.terrakok.cicerone.sample.Screens;
+import ru.terrakok.cicerone.sample.AacScreens;
 
-public class AacSecondSamplePresenter extends MvpPresenter<AacSecondSampleView> {
+public class AacSecondSamplePresenter extends MvpPresenter<MvpView> {
 
     private final Router router;
 
@@ -14,6 +15,6 @@ public class AacSecondSamplePresenter extends MvpPresenter<AacSecondSampleView> 
     }
 
     public void onAacBlankPressed() {
-        router.navigateTo(new Screens.AacBlankSampleScreen());
+        router.navigateTo(new AacScreens.AacBlankSampleScreen());
     }
 }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSampleView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSampleView.java
@@ -1,6 +1,0 @@
-package ru.terrakok.cicerone.sample.mvp.aac;
-
-import com.arellomobile.mvp.MvpView;
-
-public interface AacSecondSampleView extends MvpView {
-}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSampleView.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/aac/AacSecondSampleView.java
@@ -1,0 +1,6 @@
+package ru.terrakok.cicerone.sample.mvp.aac;
+
+import com.arellomobile.mvp.MvpView;
+
+public interface AacSecondSampleView extends MvpView {
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.java
@@ -3,6 +3,7 @@ package ru.terrakok.cicerone.sample.mvp.start;
 import com.arellomobile.mvp.MvpPresenter;
 
 import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.AacScreens;
 import ru.terrakok.cicerone.sample.Screens;
 
 /**
@@ -28,7 +29,7 @@ public class StartActivityPresenter extends MvpPresenter<StartActivityView> {
     }
 
     public void onAacFlowPressed() {
-        router.navigateTo(new Screens.AacScreenFlow());
+        router.navigateTo(new AacScreens.AacScreenFlow());
     }
 
     public void onBackPressed() {

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.java
@@ -27,6 +27,10 @@ public class StartActivityPresenter extends MvpPresenter<StartActivityView> {
         router.navigateTo(new Screens.ProfileScreen());
     }
 
+    public void onAacFlowPressed() {
+        router.navigateTo(new Screens.AacScreenFlow());
+    }
+
     public void onBackPressed() {
         router.exit();
     }

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacActivity.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacActivity.java
@@ -24,6 +24,14 @@ public class AacActivity extends MvpAppCompatActivity {
     private Navigator navigator;
 
     @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        SampleApplication.INSTANCE.getAppComponent().inject(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_aac);
+        getOrCreateNavigator();
+    }
+
+    @Override
     protected void onResumeFragments() {
         super.onResumeFragments();
         navigatorHolder.setNavigator(getOrCreateNavigator());
@@ -33,14 +41,6 @@ public class AacActivity extends MvpAppCompatActivity {
     protected void onPause() {
         navigatorHolder.removeNavigator();
         super.onPause();
-    }
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        SampleApplication.INSTANCE.getAppComponent().inject(this);
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_aac);
-        getOrCreateNavigator();
     }
 
     @Override

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacActivity.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacActivity.java
@@ -1,0 +1,57 @@
+package ru.terrakok.cicerone.sample.ui.aac;
+
+import android.os.Bundle;
+
+import com.arellomobile.mvp.MvpAppCompatActivity;
+
+import javax.inject.Inject;
+
+import ru.terrakok.cicerone.Navigator;
+import ru.terrakok.cicerone.NavigatorHolder;
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.android.aac.AacNavigator;
+import ru.terrakok.cicerone.sample.R;
+import ru.terrakok.cicerone.sample.SampleApplication;
+
+public class AacActivity extends MvpAppCompatActivity {
+
+    @Inject
+    NavigatorHolder navigatorHolder;
+
+    @Inject
+    Router router;
+
+    private Navigator navigator;
+
+    @Override
+    protected void onResumeFragments() {
+        super.onResumeFragments();
+        navigatorHolder.setNavigator(getOrCreateNavigator());
+    }
+
+    @Override
+    protected void onPause() {
+        navigatorHolder.removeNavigator();
+        super.onPause();
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        SampleApplication.INSTANCE.getAppComponent().inject(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_aac);
+        getOrCreateNavigator();
+    }
+
+    @Override
+    public void onBackPressed() {
+        router.exit();
+    }
+
+    private Navigator getOrCreateNavigator() {
+        if (navigator == null) {
+            navigator = new AacNavigator(this, R.id.nav_host_fragment);
+        }
+        return navigator;
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacBlankFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacBlankFragment.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.MvpView;
 import com.arellomobile.mvp.presenter.InjectPresenter;
 import com.arellomobile.mvp.presenter.ProvidePresenter;
 
@@ -19,9 +20,8 @@ import ru.terrakok.cicerone.Router;
 import ru.terrakok.cicerone.sample.R;
 import ru.terrakok.cicerone.sample.SampleApplication;
 import ru.terrakok.cicerone.sample.mvp.aac.AacBlankPresenter;
-import ru.terrakok.cicerone.sample.mvp.aac.AacBlankView;
 
-public class AacBlankFragment extends MvpAppCompatFragment implements AacBlankView {
+public class AacBlankFragment extends MvpAppCompatFragment implements MvpView {
 
     @Inject
     Router router;
@@ -46,8 +46,8 @@ public class AacBlankFragment extends MvpAppCompatFragment implements AacBlankVi
         View rootView = inflater.inflate(R.layout.fragment_aac_blank, container, false);
         Toolbar toolbar = rootView.findViewById(R.id.toolbar);
         toolbar.setTitle("Aac blank fragment");
-        Button btn_aac_first = rootView.findViewById(R.id.btn_aac_first);
-        btn_aac_first.setOnClickListener(new View.OnClickListener() {
+        Button btn = rootView.findViewById(R.id.aac_first_button);
+        btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 presenter.onAacFirstPressed();

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacBlankFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacBlankFragment.java
@@ -1,0 +1,58 @@
+package ru.terrakok.cicerone.sample.ui.aac;
+
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.presenter.InjectPresenter;
+import com.arellomobile.mvp.presenter.ProvidePresenter;
+
+import javax.inject.Inject;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.R;
+import ru.terrakok.cicerone.sample.SampleApplication;
+import ru.terrakok.cicerone.sample.mvp.aac.AacBlankPresenter;
+import ru.terrakok.cicerone.sample.mvp.aac.AacBlankView;
+
+public class AacBlankFragment extends MvpAppCompatFragment implements AacBlankView {
+
+    @Inject
+    Router router;
+
+    @InjectPresenter
+    AacBlankPresenter presenter;
+
+    @ProvidePresenter
+    AacBlankPresenter providePresenter() {
+        return new AacBlankPresenter(router);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        SampleApplication.INSTANCE.getAppComponent().inject(this);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_aac_blank, container, false);
+        Toolbar toolbar = rootView.findViewById(R.id.toolbar);
+        toolbar.setTitle("Aac blank fragment");
+        Button btn_aac_first = rootView.findViewById(R.id.btn_aac_first);
+        btn_aac_first.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                presenter.onAacFirstPressed();
+            }
+        });
+        return rootView;
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacFirstSampleFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacFirstSampleFragment.java
@@ -1,0 +1,58 @@
+package ru.terrakok.cicerone.sample.ui.aac;
+
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.presenter.InjectPresenter;
+import com.arellomobile.mvp.presenter.ProvidePresenter;
+
+import javax.inject.Inject;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.R;
+import ru.terrakok.cicerone.sample.SampleApplication;
+import ru.terrakok.cicerone.sample.mvp.aac.AacFirstSamplePresenter;
+import ru.terrakok.cicerone.sample.mvp.aac.AacFirstSampleView;
+
+public class AacFirstSampleFragment extends MvpAppCompatFragment implements AacFirstSampleView {
+
+    @Inject
+    Router router;
+
+    @InjectPresenter
+    AacFirstSamplePresenter presenter;
+
+    @ProvidePresenter
+    AacFirstSamplePresenter providePresenter() {
+        return new AacFirstSamplePresenter(router);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        SampleApplication.INSTANCE.getAppComponent().inject(this);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_aac_first_sample, container, false);
+        Toolbar toolbar = rootView.findViewById(R.id.toolbar);
+        toolbar.setTitle("Aac first fragment");
+        Button btn = rootView.findViewById(R.id.btn_aac_second);
+        btn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                presenter.onAacSecondPressed();
+            }
+        });
+        return rootView;
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacFirstSampleFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacFirstSampleFragment.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.MvpView;
 import com.arellomobile.mvp.presenter.InjectPresenter;
 import com.arellomobile.mvp.presenter.ProvidePresenter;
 
@@ -19,9 +20,8 @@ import ru.terrakok.cicerone.Router;
 import ru.terrakok.cicerone.sample.R;
 import ru.terrakok.cicerone.sample.SampleApplication;
 import ru.terrakok.cicerone.sample.mvp.aac.AacFirstSamplePresenter;
-import ru.terrakok.cicerone.sample.mvp.aac.AacFirstSampleView;
 
-public class AacFirstSampleFragment extends MvpAppCompatFragment implements AacFirstSampleView {
+public class AacFirstSampleFragment extends MvpAppCompatFragment implements MvpView {
 
     @Inject
     Router router;
@@ -46,7 +46,7 @@ public class AacFirstSampleFragment extends MvpAppCompatFragment implements AacF
         View rootView = inflater.inflate(R.layout.fragment_aac_first_sample, container, false);
         Toolbar toolbar = rootView.findViewById(R.id.toolbar);
         toolbar.setTitle("Aac first fragment");
-        Button btn = rootView.findViewById(R.id.btn_aac_second);
+        Button btn = rootView.findViewById(R.id.aac_second_button);
         btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacSecondSampleFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacSecondSampleFragment.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 
 import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.MvpView;
 import com.arellomobile.mvp.presenter.InjectPresenter;
 import com.arellomobile.mvp.presenter.ProvidePresenter;
 
@@ -19,9 +20,8 @@ import ru.terrakok.cicerone.Router;
 import ru.terrakok.cicerone.sample.R;
 import ru.terrakok.cicerone.sample.SampleApplication;
 import ru.terrakok.cicerone.sample.mvp.aac.AacSecondSamplePresenter;
-import ru.terrakok.cicerone.sample.mvp.aac.AacSecondSampleView;
 
-public class AacSecondSampleFragment extends MvpAppCompatFragment implements AacSecondSampleView {
+public class AacSecondSampleFragment extends MvpAppCompatFragment implements MvpView {
 
     @Inject
     Router router;
@@ -46,7 +46,7 @@ public class AacSecondSampleFragment extends MvpAppCompatFragment implements Aac
         View rootView = inflater.inflate(R.layout.fragment_aac_second_sample, container, false);
         Toolbar toolbar = rootView.findViewById(R.id.toolbar);
         toolbar.setTitle("Aac second fragment");
-        Button btn = rootView.findViewById(R.id.btn_aac_blank);
+        Button btn = rootView.findViewById(R.id.aac_blank_button);
         btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacSecondSampleFragment.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/aac/AacSecondSampleFragment.java
@@ -1,0 +1,58 @@
+package ru.terrakok.cicerone.sample.ui.aac;
+
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.arellomobile.mvp.MvpAppCompatFragment;
+import com.arellomobile.mvp.presenter.InjectPresenter;
+import com.arellomobile.mvp.presenter.ProvidePresenter;
+
+import javax.inject.Inject;
+
+import ru.terrakok.cicerone.Router;
+import ru.terrakok.cicerone.sample.R;
+import ru.terrakok.cicerone.sample.SampleApplication;
+import ru.terrakok.cicerone.sample.mvp.aac.AacSecondSamplePresenter;
+import ru.terrakok.cicerone.sample.mvp.aac.AacSecondSampleView;
+
+public class AacSecondSampleFragment extends MvpAppCompatFragment implements AacSecondSampleView {
+
+    @Inject
+    Router router;
+
+    @InjectPresenter
+    AacSecondSamplePresenter presenter;
+
+    @ProvidePresenter
+    AacSecondSamplePresenter providePresenter() {
+        return new AacSecondSamplePresenter(router);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        SampleApplication.INSTANCE.getAppComponent().inject(this);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_aac_second_sample, container, false);
+        Toolbar toolbar = rootView.findViewById(R.id.toolbar);
+        toolbar.setTitle("Aac second fragment");
+        Button btn = rootView.findViewById(R.id.btn_aac_blank);
+        btn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                presenter.onAacBlankPressed();
+            }
+        });
+        return rootView;
+    }
+}

--- a/sample/src/main/java/ru/terrakok/cicerone/sample/ui/start/StartActivity.java
+++ b/sample/src/main/java/ru/terrakok/cicerone/sample/ui/start/StartActivity.java
@@ -66,6 +66,12 @@ public class StartActivity extends MvpAppCompatActivity implements StartActivity
                 presenter.onResultWithAnimationPressed();
             }
         });
+        findViewById(R.id.aac_flow).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                presenter.onAacFlowPressed();
+            }
+        });
     }
 
     @Override

--- a/sample/src/main/res/anim/slide_in_left.xml
+++ b/sample/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate android:fromXDelta="-100%" android:toXDelta="0%"
+               android:fromYDelta="0%" android:toYDelta="0%"
+               android:duration="300"/>
+</set>

--- a/sample/src/main/res/anim/slide_in_right.xml
+++ b/sample/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate android:fromXDelta="100%" android:toXDelta="0%"
+               android:fromYDelta="0%" android:toYDelta="0%"
+               android:duration="300"/>
+</set>

--- a/sample/src/main/res/anim/slide_out_left.xml
+++ b/sample/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate android:fromXDelta="0%" android:toXDelta="-100%"
+               android:fromYDelta="0%" android:toYDelta="0%"
+               android:duration="300"/>
+</set>

--- a/sample/src/main/res/anim/slide_out_right.xml
+++ b/sample/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <translate android:fromXDelta="0%" android:toXDelta="100%"
+               android:fromYDelta="0%" android:toYDelta="0%"
+               android:duration="300"/>
+</set>

--- a/sample/src/main/res/layout/activity_aac.xml
+++ b/sample/src/main/res/layout/activity_aac.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout android:id="@+id/container"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.aac.AacActivity">
+
+        <fragment
+            android:id="@+id/nav_host_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:navGraph="@navigation/aac_navigation"
+            app:defaultNavHost="true" />
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_start.xml
+++ b/sample/src/main/res/layout/activity_start.xml
@@ -43,4 +43,11 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
         android:text="@string/result_and_anim_nav"/>
+
+    <Button
+        android:id="@+id/aac_flow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/aac_flow"/>
 </LinearLayout>

--- a/sample/src/main/res/layout/fragment_aac_blank.xml
+++ b/sample/src/main/res/layout/fragment_aac_blank.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.aac.AacBlankFragment">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/primary">
+    </android.support.v7.widget.Toolbar>
+
+    <Button
+        android:id="@+id/btn_aac_first"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/btn_aac_first" />
+
+</FrameLayout>

--- a/sample/src/main/res/layout/fragment_aac_blank.xml
+++ b/sample/src/main/res/layout/fragment_aac_blank.xml
@@ -13,10 +13,10 @@
     </android.support.v7.widget.Toolbar>
 
     <Button
-        android:id="@+id/btn_aac_first"
+        android:id="@+id/aac_first_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:text="@string/btn_aac_first" />
+        android:text="@string/aac_first" />
 
 </FrameLayout>

--- a/sample/src/main/res/layout/fragment_aac_first_sample.xml
+++ b/sample/src/main/res/layout/fragment_aac_first_sample.xml
@@ -10,10 +10,10 @@
     </android.support.v7.widget.Toolbar>
 
     <Button
-        android:id="@+id/btn_aac_second"
+        android:id="@+id/aac_second_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:text="@string/btn_aac_second"/>
+        android:text="@string/aac_second"/>
 
 </FrameLayout>

--- a/sample/src/main/res/layout/fragment_aac_first_sample.xml
+++ b/sample/src/main/res/layout/fragment_aac_first_sample.xml
@@ -1,0 +1,19 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/primary">
+    </android.support.v7.widget.Toolbar>
+
+    <Button
+        android:id="@+id/btn_aac_second"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/btn_aac_second"/>
+
+</FrameLayout>

--- a/sample/src/main/res/layout/fragment_aac_second_sample.xml
+++ b/sample/src/main/res/layout/fragment_aac_second_sample.xml
@@ -13,10 +13,10 @@
     </android.support.v7.widget.Toolbar>
 
     <Button
-        android:id="@+id/btn_aac_blank"
+        android:id="@+id/aac_blank_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:text="@string/btn_aac_blank"/>
+        android:text="@string/aac_blank"/>
 
 </FrameLayout>

--- a/sample/src/main/res/layout/fragment_aac_second_sample.xml
+++ b/sample/src/main/res/layout/fragment_aac_second_sample.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.aac.AacSecondSampleFragment">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/primary">
+    </android.support.v7.widget.Toolbar>
+
+    <Button
+        android:id="@+id/btn_aac_blank"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/btn_aac_blank"/>
+
+</FrameLayout>

--- a/sample/src/main/res/navigation/aac_navigation.xml
+++ b/sample/src/main/res/navigation/aac_navigation.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            app:startDestination="@+id/fragment_aac_blank">
+
+    <fragment
+        android:id="@+id/fragment_aac_blank"
+        android:name="ru.terrakok.cicerone.sample.ui.aac.AacBlankFragment"
+        android:label="Aac blank fragment"
+        tools:layout="@layout/fragment_aac_blank">
+
+        <action
+            android:id="@+id/next_action_aac_first"
+            app:destination="@+id/fragment_aac_first"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"
+             />
+    </fragment>
+
+    <fragment
+        android:id="@+id/fragment_aac_first"
+        android:name="ru.terrakok.cicerone.sample.ui.aac.AacFirstSampleFragment"
+        android:label="Aac first fragment"
+        tools:layout="@layout/fragment_aac_first_sample">
+
+        <action
+            android:id="@+id/next_action_aac_second"
+            app:destination="@+id/fragment_aac_second"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"
+            />
+    </fragment>
+
+    <fragment
+        android:id="@+id/fragment_aac_second"
+        android:name="ru.terrakok.cicerone.sample.ui.aac.AacSecondSampleFragment"
+        android:label="Aac second fragment"
+        tools:layout="@layout/fragment_aac_second_sample">
+
+        <action
+            android:id="@+id/next_action_aac_blank"
+            app:popUpTo="@+id/fragment_aac_blank"
+            app:popUpToInclusive="false"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"
+            />
+    </fragment>
+</navigation>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,8 +4,13 @@
     <string name="ordinary_nav">Ordinary navigation</string>
     <string name="multi_nav">Multi navigation</string>
     <string name="result_and_anim_nav">Resulting and animation sample</string>
+    <string name="aac_flow">Android architecture components navigation</string>
 
     <string name="tab_android">Android</string>
     <string name="tab_bug">Bug</string>
     <string name="tab_dog">Dog</string>
+
+    <string name="btn_aac_blank">Aac blank fragment</string>
+    <string name="btn_aac_first">Aac first fragment</string>
+    <string name="btn_aac_second">Aac second fragment</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="tab_bug">Bug</string>
     <string name="tab_dog">Dog</string>
 
-    <string name="btn_aac_blank">Aac blank fragment</string>
-    <string name="btn_aac_first">Aac first fragment</string>
-    <string name="btn_aac_second">Aac second fragment</string>
+    <string name="aac_blank">Aac blank fragment</string>
+    <string name="aac_first">Aac first fragment</string>
+    <string name="aac_second">Aac second fragment</string>
 </resources>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':library', ':sample', ':stub-android'
+include ':library', ':sample', ':stub-android', ':aac_navigation'
 project(':stub-android').projectDir = new File('library/stub-android')


### PR DESCRIPTION
I've added `AacNavigator` which makes a friendship between Cicerone and Navigation Architecture Component from Jetpack :). 

So, it makes a possibility to work with Cicerone and see navigation graph using  Navigation Architecture Component. It helps to see the map of navigation. Once NAC becomes stable it will be useful to use it in production I hope.