### PR TITLE
Add androidx nullability annotations

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,6 +8,7 @@ targetCompatibility = JavaVersion.VERSION_1_7
 dependencies {
     compileOnly project(':stub-android')
     compileOnly 'com.google.android:android:4.1.1.4'
+    compile "org.jetbrains:annotations:16.0.3"
 }
 
 ext {
@@ -24,7 +25,7 @@ ext {
 // Configuration of the library uploading to the Bintray
 // Note: Call 'bintrayUpload' task (it will execute 'install' task first)
 // I try to include as little properties as possible in these files
-project.archivesBaseName ='cicerone' // to fix that project name different from artifact name
+project.archivesBaseName = 'cicerone' // to fix that project name different from artifact name
 apply from: 'androidmaven.gradle'
 apply from: 'bintray.gradle'
 

--- a/library/src/main/java/ru/terrakok/cicerone/BaseRouter.java
+++ b/library/src/main/java/ru/terrakok/cicerone/BaseRouter.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+
 import ru.terrakok.cicerone.commands.Command;
 
 /**
@@ -17,6 +19,7 @@ public abstract class BaseRouter {
         this.commandBuffer = new CommandBuffer();
     }
 
+    @NotNull
     CommandBuffer getCommandBuffer() {
         return commandBuffer;
     }
@@ -26,7 +29,7 @@ public abstract class BaseRouter {
      *
      * @param commands navigation command array to execute
      */
-    protected void executeCommands(Command... commands) {
+    protected void executeCommands(@NotNull Command... commands) {
         commandBuffer.executeCommands(commands);
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/Cicerone.java
+++ b/library/src/main/java/ru/terrakok/cicerone/Cicerone.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Cicerone is the holder for other library components.
  * To use it, instantiate it using one of the {@link #create()} methods.
@@ -15,14 +17,16 @@ package ru.terrakok.cicerone;
 public class Cicerone<T extends BaseRouter> {
     private T router;
 
-    private Cicerone(T router) {
+    private Cicerone(@NotNull T router) {
         this.router = router;
     }
 
+    @NotNull
     public NavigatorHolder getNavigatorHolder() {
         return router.getCommandBuffer();
     }
 
+    @NotNull
     public T getRouter() {
         return router;
     }
@@ -30,6 +34,7 @@ public class Cicerone<T extends BaseRouter> {
     /**
      * Creates the Cicerone instance with the default {@link Router router}
      */
+    @NotNull
     public static Cicerone<Router> create() {
         return create(new Router());
     }
@@ -38,7 +43,8 @@ public class Cicerone<T extends BaseRouter> {
      * Creates the Cicerone instance with the custom router.
      * @param customRouter the custom router extending {@link BaseRouter}
      */
-    public static <T extends BaseRouter> Cicerone<T> create(T customRouter) {
+    @NotNull
+    public static <T extends BaseRouter> Cicerone<T> create(@NotNull T customRouter) {
         return new Cicerone<>(customRouter);
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/CommandBuffer.java
+++ b/library/src/main/java/ru/terrakok/cicerone/CommandBuffer.java
@@ -4,6 +4,9 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -18,7 +21,7 @@ class CommandBuffer implements NavigatorHolder {
     private Queue<Command[]> pendingCommands = new LinkedList<>();
 
     @Override
-    public void setNavigator(Navigator navigator) {
+    public void setNavigator(@Nullable Navigator navigator) {
         this.navigator = navigator;
         while (!pendingCommands.isEmpty()) {
             if (navigator != null) {
@@ -37,7 +40,7 @@ class CommandBuffer implements NavigatorHolder {
      * Else puts it to the pending commands queue to pass it later.
      * @param commands navigation command array
      */
-    void executeCommands(Command[] commands) {
+    void executeCommands(@NotNull Command[] commands) {
         if (navigator != null) {
             navigator.applyCommands(commands);
         } else {

--- a/library/src/main/java/ru/terrakok/cicerone/Navigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/Navigator.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+
 import ru.terrakok.cicerone.commands.Command;
 
 /**
@@ -17,5 +19,5 @@ public interface Navigator {
      *
      * @param commands the navigation command array to apply per single transaction
      */
-    void applyCommands(Command[] commands);
+    void applyCommands(@NotNull Command[] commands);
 }

--- a/library/src/main/java/ru/terrakok/cicerone/NavigatorHolder.java
+++ b/library/src/main/java/ru/terrakok/cicerone/NavigatorHolder.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Navigator holder interface.
  * Use it to connect a {@link Navigator} to the {@link Cicerone}.
@@ -15,7 +17,7 @@ public interface NavigatorHolder {
      *
      * @param navigator new active Navigator
      */
-    void setNavigator(Navigator navigator);
+    void setNavigator(@NotNull Navigator navigator);
 
     /**
      * Remove the current Navigator and stop receive commands.

--- a/library/src/main/java/ru/terrakok/cicerone/Router.java
+++ b/library/src/main/java/ru/terrakok/cicerone/Router.java
@@ -4,6 +4,9 @@
 
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import ru.terrakok.cicerone.commands.Back;
 import ru.terrakok.cicerone.commands.BackTo;
 import ru.terrakok.cicerone.commands.Command;
@@ -27,7 +30,7 @@ public class Router extends BaseRouter {
      *
      * @param screen screen
      */
-    public void navigateTo(Screen screen) {
+    public void navigateTo(@NotNull Screen screen) {
         executeCommands(new Forward(screen));
     }
 
@@ -36,7 +39,7 @@ public class Router extends BaseRouter {
      *
      * @param screen screen
      */
-    public void newRootScreen(Screen screen) {
+    public void newRootScreen(@NotNull Screen screen) {
         executeCommands(
                 new BackTo(null),
                 new Replace(screen)
@@ -51,7 +54,7 @@ public class Router extends BaseRouter {
      *
      * @param screen screen
      */
-    public void replaceScreen(Screen screen) {
+    public void replaceScreen(@NotNull Screen screen) {
         executeCommands(new Replace(screen));
     }
 
@@ -62,7 +65,7 @@ public class Router extends BaseRouter {
      *
      * @param screen screen
      */
-    public void backTo(Screen screen) {
+    public void backTo(@Nullable Screen screen) {
         executeCommands(new BackTo(screen));
     }
 
@@ -70,7 +73,7 @@ public class Router extends BaseRouter {
      * Opens several screens inside single transaction.
      * @param screens
      */
-    public void newChain(Screen... screens) {
+    public void newChain(@NotNull Screen... screens) {
         Command[] commands = new Command[screens.length];
         for (int i = 0; i < commands.length; i++) {
             commands[i] = new Forward(screens[i]);
@@ -82,7 +85,7 @@ public class Router extends BaseRouter {
      * Clear current stack and open several screens inside single transaction.
      * @param screens
      */
-    public void newRootChain(Screen... screens) {
+    public void newRootChain(@NotNull Screen... screens) {
         Command[] commands = new Command[screens.length + 1];
         commands[0] = new BackTo(null);
         if (screens.length > 0) {

--- a/library/src/main/java/ru/terrakok/cicerone/Screen.java
+++ b/library/src/main/java/ru/terrakok/cicerone/Screen.java
@@ -1,11 +1,14 @@
 package ru.terrakok.cicerone;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Screen is class for description application screen.
  */
 public abstract class Screen {
     protected String screenKey = getClass().getCanonicalName();
 
+    @NotNull
     public String getScreenKey() {
         return screenKey;
     }

--- a/library/src/main/java/ru/terrakok/cicerone/android/pure/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/pure/AppNavigator.java
@@ -7,6 +7,9 @@ import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.LinkedList;
 
 import ru.terrakok.cicerone.Navigator;
@@ -28,18 +31,18 @@ public class AppNavigator implements Navigator {
     private final int containerId;
     private LinkedList<String> localStackCopy;
 
-    public AppNavigator(Activity activity, int containerId) {
+    public AppNavigator(@NotNull Activity activity, int containerId) {
         this(activity, activity.getFragmentManager(), containerId);
     }
 
-    public AppNavigator(Activity activity, FragmentManager fragmentManager, int containerId) {
+    public AppNavigator(@NotNull Activity activity, @NotNull FragmentManager fragmentManager, int containerId) {
         this.activity = activity;
         this.fragmentManager = fragmentManager;
         this.containerId = containerId;
     }
 
     @Override
-    public void applyCommands(Command[] commands) {
+    public void applyCommands(@NotNull Command[] commands) {
         fragmentManager.executePendingTransactions();
 
         //copy stack before apply commands
@@ -64,7 +67,7 @@ public class AppNavigator implements Navigator {
      *
      * @param command the navigation command to apply
      */
-    protected void applyCommand(Command command) {
+    protected void applyCommand(@NotNull Command command) {
         if (command instanceof Forward) {
             activityForward((Forward) command);
         } else if (command instanceof Replace) {
@@ -77,7 +80,7 @@ public class AppNavigator implements Navigator {
     }
 
 
-    protected void activityForward(Forward command) {
+    protected void activityForward(@NotNull Forward command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Intent activityIntent = screen.getActivityIntent(activity);
 
@@ -90,7 +93,7 @@ public class AppNavigator implements Navigator {
         }
     }
 
-    protected void fragmentForward(Forward command) {
+    protected void fragmentForward(@NotNull Forward command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
 
@@ -123,7 +126,7 @@ public class AppNavigator implements Navigator {
         activity.finish();
     }
 
-    protected void activityReplace(Replace command) {
+    protected void activityReplace(@NotNull Replace command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Intent activityIntent = screen.getActivityIntent(activity);
 
@@ -137,7 +140,7 @@ public class AppNavigator implements Navigator {
         }
     }
 
-    protected void fragmentReplace(Replace command) {
+    protected void fragmentReplace(@NotNull Replace command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
 
@@ -179,7 +182,7 @@ public class AppNavigator implements Navigator {
     /**
      * Performs {@link BackTo} command transition
      */
-    protected void backTo(BackTo command) {
+    protected void backTo(@NotNull BackTo command) {
         if (command.getScreen() == null) {
             backToRoot();
         } else {
@@ -213,10 +216,10 @@ public class AppNavigator implements Navigator {
      * @param nextFragment        next screen fragment
      * @param fragmentTransaction fragment transaction
      */
-    protected void setupFragmentTransaction(Command command,
-                                            Fragment currentFragment,
-                                            Fragment nextFragment,
-                                            FragmentTransaction fragmentTransaction) {
+    protected void setupFragmentTransaction(@NotNull Command command,
+                                            @Nullable Fragment currentFragment,
+                                            @Nullable Fragment nextFragment,
+                                            @NotNull FragmentTransaction fragmentTransaction) {
     }
 
     /**
@@ -226,11 +229,14 @@ public class AppNavigator implements Navigator {
      * @param activityIntent activity intent
      * @return transition options
      */
-    protected Bundle createStartActivityOptions(Command command, Intent activityIntent) {
+    @Nullable
+    protected Bundle createStartActivityOptions(@NotNull Command command, @NotNull Intent activityIntent) {
         return null;
     }
 
-    private void checkAndStartActivity(AppScreen screen, Intent activityIntent, Bundle options) {
+    private void checkAndStartActivity(@NotNull AppScreen screen,
+                                       @NotNull Intent activityIntent,
+                                       @Nullable Bundle options) {
         // Check if we can start activity
         if (activityIntent.resolveActivity(activity.getPackageManager()) != null) {
             activity.startActivity(activityIntent, options);
@@ -245,7 +251,7 @@ public class AppNavigator implements Navigator {
      * @param screen         screen
      * @param activityIntent intent passed to start Activity for the {@code screenKey}
      */
-    protected void unexistingActivity(AppScreen screen, Intent activityIntent) {
+    protected void unexistingActivity(@NotNull AppScreen screen, @NotNull Intent activityIntent) {
         // Do nothing by default
     }
 
@@ -255,7 +261,8 @@ public class AppNavigator implements Navigator {
      * @param screen screen
      * @return instantiated fragment for the passed screen
      */
-    protected Fragment createFragment(AppScreen screen) {
+    @Nullable
+    protected Fragment createFragment(@NotNull AppScreen screen) {
         Fragment fragment = screen.getFragment();
 
         if (fragment == null) {
@@ -270,11 +277,11 @@ public class AppNavigator implements Navigator {
      *
      * @param screen screen
      */
-    protected void backToUnexisting(AppScreen screen) {
+    protected void backToUnexisting(@NotNull AppScreen screen) {
         backToRoot();
     }
 
-    protected void errorWhileCreatingScreen(AppScreen screen) {
+    protected void errorWhileCreatingScreen(@NotNull AppScreen screen) {
         throw new RuntimeException("Can't create a screen: " + screen.getScreenKey());
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/pure/AppScreen.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/pure/AppScreen.java
@@ -4,6 +4,8 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 
+import org.jetbrains.annotations.Nullable;
+
 import ru.terrakok.cicerone.Screen;
 
 /**
@@ -13,10 +15,12 @@ import ru.terrakok.cicerone.Screen;
  */
 public abstract class AppScreen extends Screen {
 
+    @Nullable
     public Fragment getFragment() {
         return null;
     }
 
+    @Nullable
     public Intent getActivityIntent(Context context) {
         return null;
     }

--- a/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppNavigator.java
@@ -3,13 +3,16 @@ package ru.terrakok.cicerone.android.support;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-
-import java.util.LinkedList;
-
 import ru.terrakok.cicerone.Navigator;
 import ru.terrakok.cicerone.commands.Back;
 import ru.terrakok.cicerone.commands.BackTo;
@@ -29,18 +32,18 @@ public class SupportAppNavigator implements Navigator {
     private final int containerId;
     private LinkedList<String> localStackCopy;
 
-    public SupportAppNavigator(FragmentActivity activity, int containerId) {
+    public SupportAppNavigator(@NotNull FragmentActivity activity, int containerId) {
         this(activity, activity.getSupportFragmentManager(), containerId);
     }
 
-    public SupportAppNavigator(FragmentActivity activity, FragmentManager fragmentManager, int containerId) {
+    public SupportAppNavigator(@NotNull FragmentActivity activity, @NotNull FragmentManager fragmentManager, int containerId) {
         this.activity = activity;
         this.fragmentManager = fragmentManager;
         this.containerId = containerId;
     }
 
     @Override
-    public void applyCommands(Command[] commands) {
+    public void applyCommands(@NotNull Command[] commands) {
         fragmentManager.executePendingTransactions();
 
         //copy stack before apply commands
@@ -65,7 +68,7 @@ public class SupportAppNavigator implements Navigator {
      *
      * @param command the navigation command to apply
      */
-    protected void applyCommand(Command command) {
+    protected void applyCommand(@NotNull Command command) {
         if (command instanceof Forward) {
             activityForward((Forward) command);
         } else if (command instanceof Replace) {
@@ -78,7 +81,7 @@ public class SupportAppNavigator implements Navigator {
     }
 
 
-    protected void activityForward(Forward command) {
+    protected void activityForward(@NotNull Forward command) {
         SupportAppScreen screen = (SupportAppScreen) command.getScreen();
         Intent activityIntent = screen.getActivityIntent(activity);
 
@@ -91,7 +94,7 @@ public class SupportAppNavigator implements Navigator {
         }
     }
 
-    protected void fragmentForward(Forward command) {
+    protected void fragmentForward(@NotNull Forward command) {
         SupportAppScreen screen = (SupportAppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
 
@@ -124,7 +127,7 @@ public class SupportAppNavigator implements Navigator {
         activity.finish();
     }
 
-    protected void activityReplace(Replace command) {
+    protected void activityReplace(@NotNull Replace command) {
         SupportAppScreen screen = (SupportAppScreen) command.getScreen();
         Intent activityIntent = screen.getActivityIntent(activity);
 
@@ -138,7 +141,7 @@ public class SupportAppNavigator implements Navigator {
         }
     }
 
-    protected void fragmentReplace(Replace command) {
+    protected void fragmentReplace(@NotNull Replace command) {
         SupportAppScreen screen = (SupportAppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
 
@@ -180,7 +183,7 @@ public class SupportAppNavigator implements Navigator {
     /**
      * Performs {@link BackTo} command transition
      */
-    protected void backTo(BackTo command) {
+    protected void backTo(@NotNull BackTo command) {
         if (command.getScreen() == null) {
             backToRoot();
         } else {
@@ -214,10 +217,10 @@ public class SupportAppNavigator implements Navigator {
      * @param nextFragment        next screen fragment
      * @param fragmentTransaction fragment transaction
      */
-    protected void setupFragmentTransaction(Command command,
-                                            Fragment currentFragment,
-                                            Fragment nextFragment,
-                                            FragmentTransaction fragmentTransaction) {
+    protected void setupFragmentTransaction(@NotNull Command command,
+                                            @Nullable Fragment currentFragment,
+                                            @Nullable Fragment nextFragment,
+                                            @NotNull FragmentTransaction fragmentTransaction) {
     }
 
     /**
@@ -227,11 +230,12 @@ public class SupportAppNavigator implements Navigator {
      * @param activityIntent activity intent
      * @return transition options
      */
-    protected Bundle createStartActivityOptions(Command command, Intent activityIntent) {
+    @Nullable
+    protected Bundle createStartActivityOptions(@NotNull Command command, @NotNull Intent activityIntent) {
         return null;
     }
 
-    private void checkAndStartActivity(SupportAppScreen screen, Intent activityIntent, Bundle options) {
+    private void checkAndStartActivity(@NotNull SupportAppScreen screen, @NotNull Intent activityIntent, @Nullable Bundle options) {
         // Check if we can start activity
         if (activityIntent.resolveActivity(activity.getPackageManager()) != null) {
             activity.startActivity(activityIntent, options);
@@ -246,7 +250,7 @@ public class SupportAppNavigator implements Navigator {
      * @param screen         screen
      * @param activityIntent intent passed to start Activity for the {@code screenKey}
      */
-    protected void unexistingActivity(SupportAppScreen screen, Intent activityIntent) {
+    protected void unexistingActivity(@NotNull SupportAppScreen screen, @NotNull Intent activityIntent) {
         // Do nothing by default
     }
 
@@ -256,7 +260,8 @@ public class SupportAppNavigator implements Navigator {
      * @param screen screen
      * @return instantiated fragment for the passed screen
      */
-    protected Fragment createFragment(SupportAppScreen screen) {
+    @Nullable
+    protected Fragment createFragment(@NotNull SupportAppScreen screen) {
         Fragment fragment = screen.getFragment();
 
         if (fragment == null) {
@@ -271,11 +276,11 @@ public class SupportAppNavigator implements Navigator {
      *
      * @param screen screen
      */
-    protected void backToUnexisting(SupportAppScreen screen) {
+    protected void backToUnexisting(@NotNull SupportAppScreen screen) {
         backToRoot();
     }
 
-    protected void errorWhileCreatingScreen(SupportAppScreen screen) {
+    protected void errorWhileCreatingScreen(@NotNull SupportAppScreen screen) {
         throw new RuntimeException("Can't create a screen: " + screen.getScreenKey());
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppScreen.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppScreen.java
@@ -2,8 +2,11 @@ package ru.terrakok.cicerone.android.support;
 
 import android.content.Context;
 import android.content.Intent;
-import androidx.fragment.app.Fragment;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import androidx.fragment.app.Fragment;
 import ru.terrakok.cicerone.Screen;
 
 /**
@@ -13,11 +16,13 @@ import ru.terrakok.cicerone.Screen;
  */
 public abstract class SupportAppScreen extends Screen {
 
+    @Nullable
     public Fragment getFragment() {
         return null;
     }
 
-    public Intent getActivityIntent(Context context) {
+    @Nullable
+    public Intent getActivityIntent(@NotNull Context context) {
         return null;
     }
 }

--- a/library/src/main/java/ru/terrakok/cicerone/commands/BackTo.java
+++ b/library/src/main/java/ru/terrakok/cicerone/commands/BackTo.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone.commands;
 
+import org.jetbrains.annotations.Nullable;
+
 import ru.terrakok.cicerone.Navigator;
 import ru.terrakok.cicerone.Screen;
 
@@ -20,10 +22,11 @@ public class BackTo implements Command {
      *
      * @param screen screen
      */
-    public BackTo(Screen screen) {
+    public BackTo(@Nullable Screen screen) {
         this.screen = screen;
     }
 
+    @Nullable
     public Screen getScreen() {
         return screen;
     }

--- a/library/src/main/java/ru/terrakok/cicerone/commands/Forward.java
+++ b/library/src/main/java/ru/terrakok/cicerone/commands/Forward.java
@@ -4,6 +4,8 @@
 
 package ru.terrakok.cicerone.commands;
 
+import org.jetbrains.annotations.NotNull;
+
 import ru.terrakok.cicerone.Screen;
 
 /**
@@ -17,10 +19,11 @@ public class Forward implements Command {
      *
      * @param screen screen
      */
-    public Forward(Screen screen) {
+    public Forward(@NotNull Screen screen) {
         this.screen = screen;
     }
 
+    @NotNull
     public Screen getScreen() {
         return screen;
     }

--- a/library/src/main/java/ru/terrakok/cicerone/commands/Replace.java
+++ b/library/src/main/java/ru/terrakok/cicerone/commands/Replace.java
@@ -4,12 +4,15 @@
 
 package ru.terrakok.cicerone.commands;
 
+import org.jetbrains.annotations.NotNull;
+
 import ru.terrakok.cicerone.Screen;
 
 /**
  * Replaces the current screen.
  */
 public class Replace implements Command {
+    @NotNull
     private Screen screen;
 
     /**
@@ -17,10 +20,11 @@ public class Replace implements Command {
      *
      * @param screen screen
      */
-    public Replace(Screen screen) {
+    public Replace(@NotNull Screen screen) {
         this.screen = screen;
     }
 
+    @NotNull
     public Screen getScreen() {
         return screen;
     }


### PR DESCRIPTION
These annotations will help kotlin users extend abstract classes, java users will benefit from these annotations as well.
On the other hand this change will break written kotlin code in some cases, for example when extending SupportAppNavigator:

```class MyNavigator(fragment: Fragment, ...) : SupportAppNavigator(fragment.activity, ...)```

Here `fragment.activity` type is `FragmentActivity?`. In current version SupportAppNavigator accepts platform-type `FragmentActivity!`, but with annotations it becomes `FragmentActivity`, which wont compile without explicitly calling `fragment.activity!!`.