### PR TITLE
Add screen key as tag to transaction replace

### DIFF
--- a/library/src/main/java/ru/terrakok/cicerone/android/pure/AppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/pure/AppNavigator.java
@@ -94,6 +94,7 @@ public class AppNavigator implements Navigator {
     protected void fragmentForward(@NotNull Forward command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
+        String screenKey = screen.getScreenKey();
 
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 
@@ -105,10 +106,10 @@ public class AppNavigator implements Navigator {
         );
 
         fragmentTransaction
-                .replace(containerId, fragment)
-                .addToBackStack(screen.getScreenKey())
+                .replace(containerId, fragment, screenKey)
+                .addToBackStack(screenKey)
                 .commit();
-        localStackCopy.add(screen.getScreenKey());
+        localStackCopy.add(screenKey);
     }
 
     protected void fragmentBack() {
@@ -141,6 +142,7 @@ public class AppNavigator implements Navigator {
     protected void fragmentReplace(@NotNull Replace command) {
         AppScreen screen = (AppScreen) command.getScreen();
         Fragment fragment = createFragment(screen);
+        String screenKey = screen.getScreenKey();
 
         if (localStackCopy.size() > 0) {
             fragmentManager.popBackStack();
@@ -156,10 +158,10 @@ public class AppNavigator implements Navigator {
             );
 
             fragmentTransaction
-                    .replace(containerId, fragment)
-                    .addToBackStack(screen.getScreenKey())
+                    .replace(containerId, fragment, screenKey)
+                    .addToBackStack(screenKey)
                     .commit();
-            localStackCopy.add(screen.getScreenKey());
+            localStackCopy.add(screenKey);
 
         } else {
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
@@ -172,7 +174,7 @@ public class AppNavigator implements Navigator {
             );
 
             fragmentTransaction
-                    .replace(containerId, fragment)
+                    .replace(containerId, fragment, screenKey)
                     .commit();
         }
     }

--- a/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppNavigator.java
+++ b/library/src/main/java/ru/terrakok/cicerone/android/support/SupportAppNavigator.java
@@ -193,17 +193,19 @@ public class SupportAppNavigator implements Navigator {
             @Nullable FragmentParams params,
             @Nullable Fragment fragment
     ) {
+        String screenKey = screen.getScreenKey();
         if (params != null) {
             transaction.replace(
                     containerId,
                     params.getFragmentClass(),
-                    params.getArguments()
+                    params.getArguments(),
+                    screenKey
             );
         } else if (fragment != null) {
-            transaction.replace(containerId, fragment);
+            transaction.replace(containerId, fragment, screenKey);
         } else {
             throw new IllegalArgumentException("Either 'params' or 'fragment' shouldn't " +
-                    "be null for " + screen.getScreenKey());
+                    "be null for " + screenKey);
         }
     }
 

--- a/library/stub-android/src/main/java/androidx/fragment/app/FragmentTransaction.java
+++ b/library/stub-android/src/main/java/androidx/fragment/app/FragmentTransaction.java
@@ -8,14 +8,15 @@ import android.os.Bundle;
  */
 
 public class FragmentTransaction {
-    public FragmentTransaction replace(int containerViewId, Fragment fragment) {
+    public FragmentTransaction replace(int containerViewId, Fragment fragment, String tag) {
         throw new RuntimeException("Stub!");
     }
 
     public final FragmentTransaction replace(
             int containerViewId,
             Class<? extends Fragment> fragmentClass,
-            Bundle args) {
+            Bundle args,
+            String tag) {
         throw new RuntimeException("Stub!");
     }
 


### PR DESCRIPTION
Anyway tag added as null. 
It will help to extract fragment if it exist in fragment manager.
For me it helps while navigating with bottom navigation(don't create if fragment exist).

Example:
```
@Override
protected @Nullable Fragment createFragment(@NotNull SupportAppScreen screen) {
    Fragment oldFragment = fragmentManager.findFragmentByTag(screen.getScreenKey());
    if (oldFragment != null) return oldFragment;
    return super.createFragment(screen);
}
```