### PR TITLE
Add license information to POM file on maven repository.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -56,6 +56,14 @@ publishing {
             artifact sourcesJar
             artifact javadocJar
             from components.java
+            pom {
+                licenses {
+                    license {
+                        name = "MIT"
+                        url = "https://opensource.org/licenses/MIT"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
License information is required for [oss-licenses-plugin](https://developers.google.com/android/guides/opensource). With license information Cicerone will appear on libraries list generated by plugin.