### PR TITLE
Added serialization / deserialization ability for AppScreen

### DIFF
--- a/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppScreen.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppScreen.kt
@@ -6,10 +6,11 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import com.github.terrakok.cicerone.Screen
+import java.io.Serializable
 
-sealed class AppScreen : Screen
+sealed class AppScreen : Screen, Serializable
 
-fun interface Creator<A, R> {
+fun interface Creator<A, R>: Serializable {
     fun create(argument: A): R
 }
 

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/Screens.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/Screens.kt
@@ -28,8 +28,11 @@ object Screens {
         Intent(it, StartActivity::class.java)
     }
 
-    fun Main() = ActivityScreen {
-        Intent(it, MainActivity::class.java)
+    // Consider to use val and upper-case naming
+    val MAIN = ActivityScreen {
+        Intent(it, MainActivity::class.java).apply {
+            putExtra("sampleScreen", Sample(1))
+        }
     }
 
     fun BottomNavigation() = ActivityScreen {

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/mvp/start/StartActivityPresenter.kt
@@ -1,8 +1,8 @@
 package com.github.terrakok.cicerone.sample.mvp.start
 
 import com.github.terrakok.cicerone.Router
+import com.github.terrakok.cicerone.sample.Screens
 import com.github.terrakok.cicerone.sample.Screens.BottomNavigation
-import com.github.terrakok.cicerone.sample.Screens.Main
 import com.github.terrakok.cicerone.sample.Screens.Profile
 import moxy.MvpPresenter
 
@@ -12,7 +12,7 @@ import moxy.MvpPresenter
 class StartActivityPresenter(private val router: Router) : MvpPresenter<StartActivityView>() {
 
     fun onOrdinaryPressed() {
-        router.navigateTo(Main())
+        router.navigateTo(Screens.MAIN)
     }
 
     fun onMultiPressed() {

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/MainActivity.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/MainActivity.kt
@@ -8,7 +8,9 @@ import com.github.terrakok.cicerone.Command
 import com.github.terrakok.cicerone.Navigator
 import com.github.terrakok.cicerone.NavigatorHolder
 import com.github.terrakok.cicerone.Replace
+import com.github.terrakok.cicerone.Router
 import com.github.terrakok.cicerone.androidx.AppNavigator
+import com.github.terrakok.cicerone.androidx.FragmentScreen
 import com.github.terrakok.cicerone.sample.R
 import com.github.terrakok.cicerone.sample.SampleApplication
 import com.github.terrakok.cicerone.sample.Screens.Sample
@@ -31,6 +33,9 @@ class MainActivity : MvpAppCompatActivity(), ChainHolder {
     @Inject
     lateinit var navigatorHolder: NavigatorHolder
 
+    @Inject
+    lateinit var router: Router
+
     private val navigator: Navigator = object : AppNavigator(this, R.id.main_container) {
 
         override fun applyCommands(commands: Array<out Command>) {
@@ -48,7 +53,9 @@ class MainActivity : MvpAppCompatActivity(), ChainHolder {
         screensSchemeTV = findViewById<View>(R.id.screens_scheme) as TextView
 
         if (savedInstanceState == null) {
-            navigator.applyCommands(arrayOf<Command>(Replace(Sample(1))))
+            // Just for sample of deserialization
+            val sampleScreen = intent.getSerializableExtra("sampleScreen") as FragmentScreen
+            router.replaceScreen(sampleScreen)
         } else {
             printScreensScheme()
         }


### PR DESCRIPTION
Hi!

I'm using Cicerone 5.0.0 and in this version serialization worked fine. After update to 6.6.0 I found, that serialization doesn't work. Serialization saw broken by **AppScreen** and **Creator<A, R>**.

Also naming of functions in Screens object starts with upper-case letter and lint warns us about it.
<img width="631" alt="Снимок экрана 2021-02-17 в 11 02 18" src="https://user-images.githubusercontent.com/4238662/108173816-ab75bc00-710f-11eb-9037-9bd3b2e6ad23.png">
I suggest to change functions to **val** and user UPPER-case naming 


