### PR TITLE
Add navigation transactions in message queue

### DIFF
--- a/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppNavigator.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppNavigator.kt
@@ -2,6 +2,8 @@ package com.github.terrakok.cicerone.androidx
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import androidx.fragment.app.*
 import com.github.terrakok.cicerone.*
 import com.github.terrakok.cicerone.androidx.TransactionInfo.Type.ADD
@@ -22,8 +24,15 @@ open class AppNavigator @JvmOverloads constructor(
 ) : Navigator {
 
     protected val localStackCopy = mutableListOf<TransactionInfo>()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun applyCommands(commands: Array<out Command>) {
+        mainHandler.post {
+            applyCommandsSync(commands)
+        }
+    }
+
+    protected open fun applyCommandsSync(commands: Array<out Command>) {
         fragmentManager.executePendingTransactions()
 
         //copy stack before apply commands

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/MainActivity.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/MainActivity.kt
@@ -33,8 +33,8 @@ class MainActivity : MvpAppCompatActivity(), ChainHolder {
 
     private val navigator: Navigator = object : AppNavigator(this, R.id.main_container) {
 
-        override fun applyCommands(commands: Array<out Command>) {
-            super.applyCommands(commands)
+        override fun applyCommandsSync(commands: Array<out Command>) {
+            super.applyCommandsSync(commands)
             supportFragmentManager.executePendingTransactions()
             printScreensScheme()
         }


### PR DESCRIPTION
Бывают кейсы, когда нужно выполнить навигацию вне Main потока (например, когда нужно открыть LoginActivity при определенном ответе из Interceptor). В таком случае было бы удобно, если бы все команды переключались бы на Main поток внутриCicerone (с фрагментами можно работать только из Main потока). На сколько это актуально было бы внести в либу? Вприцнипе реализуется 10-ю строчками кода +  ошибка FragmentManager is already executing transactions больше возникать не будет. При выполнении многих ранзакций почти одновременно эта ошибка все равно будет возникать без добавления сообщений в очередь сообщений

От Константина (https://t.me/Cicerone_RUS/11631): 
"про многопоточку: это ответственность разработчика следить за синхронизацией и вызывать команды на роутере синхронно.
но выполнять команды на фрагментменеджере не напрямую, а через отправку сообщений - норм идея"