### PR TITLE
Fix bugs with identical screen keys

### DIFF
--- a/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppScreen.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/androidx/AppScreen.kt
@@ -18,7 +18,7 @@ open class FragmentScreen @JvmOverloads constructor(
     val clearContainer: Boolean = true,
     private val fragmentCreator: Creator<FragmentFactory, Fragment>
 ) : AppScreen() {
-    override val screenKey: String get() = key ?: super.screenKey
+    override val screenKey: String get() = key ?: fragmentCreator::class.java.name
     fun createFragment(factory: FragmentFactory) = fragmentCreator.create(factory)
 }
 
@@ -26,7 +26,7 @@ open class ActivityScreen @JvmOverloads constructor(
     private val key: String? = null,
     private val intentCreator: Creator<Context, Intent>
 ) : AppScreen() {
-    override val screenKey: String get() = key ?: super.screenKey
+    override val screenKey: String get() = key ?: intentCreator::class.java.name
     open val startActivityOptions: Bundle? = null
     fun createIntent(context: Context) = intentCreator.create(context)
 }


### PR DESCRIPTION
В группе часто писали об ошибки с backTo. Данная команда не работало по причине того, что по умолчанию все ключи для экранов были ...FragmentScreen, либо ...ActivityScreen. И чтобы использовать backTo допустим в такой ситуации (стек экранов: A-B-C и хочется сделать backTo(A)) приходилось в конструкторе явно прописывать screenKey.
После исправления screenKey будет выглядеть примерно вот так:
![image](https://user-images.githubusercontent.com/31543871/115105963-a47df500-9f6a-11eb-9c61-9fe40942950f.png)
