### PR TITLE
Add sample for ClearContainer = false property of FragmentScreen

### DIFF
--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/Screens.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/Screens.kt
@@ -12,6 +12,7 @@ import com.github.terrakok.cicerone.sample.ui.bottom.ForwardFragment
 import com.github.terrakok.cicerone.sample.ui.bottom.TabContainerFragment
 import com.github.terrakok.cicerone.sample.ui.main.MainActivity
 import com.github.terrakok.cicerone.sample.ui.main.SampleFragment
+import com.github.terrakok.cicerone.sample.ui.main.SemiTransparentFragment
 import com.github.terrakok.cicerone.sample.ui.start.StartActivity
 
 /**
@@ -58,5 +59,9 @@ object Screens {
 
     fun SelectPhoto(resultKey: String) = FragmentScreen {
         SelectPhotoFragment.getNewInstance(resultKey)
+    }
+
+    fun SemiTransparent() = FragmentScreen(clearContainer = false) {
+        SemiTransparentFragment()
     }
 }

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/dagger/AppComponent.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/dagger/AppComponent.kt
@@ -9,6 +9,7 @@ import com.github.terrakok.cicerone.sample.ui.bottom.BottomNavigationActivity
 import com.github.terrakok.cicerone.sample.ui.bottom.TabContainerFragment
 import com.github.terrakok.cicerone.sample.ui.main.MainActivity
 import com.github.terrakok.cicerone.sample.ui.main.SampleFragment
+import com.github.terrakok.cicerone.sample.ui.main.SemiTransparentFragment
 import com.github.terrakok.cicerone.sample.ui.start.StartActivity
 import dagger.Component
 import javax.inject.Singleton
@@ -37,4 +38,6 @@ interface AppComponent {
     fun inject(fragment: SelectPhotoFragment)
 
     fun inject(activity: ProfileActivity)
+
+    fun inject(fragment: SemiTransparentFragment)
 }

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/mvp/main/SamplePresenter.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/mvp/main/SamplePresenter.kt
@@ -3,6 +3,7 @@ package com.github.terrakok.cicerone.sample.mvp.main
 import android.os.Handler
 import android.os.Looper
 import com.github.terrakok.cicerone.Router
+import com.github.terrakok.cicerone.sample.Screens
 import com.github.terrakok.cicerone.sample.Screens.Sample
 import moxy.InjectViewState
 import moxy.MvpPresenter
@@ -54,6 +55,10 @@ class SamplePresenter(
 
     fun onFinishChainCommandClick() {
         router.finishChain()
+    }
+
+    fun onForwardNccCommandClick() {
+        router.navigateTo(Screens.SemiTransparent())
     }
 
     fun onNewRootCommandClick() {

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SampleFragment.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SampleFragment.kt
@@ -59,6 +59,7 @@ class SampleFragment : BaseFragment(), SampleView, BackButtonListener {
         binding.forwardDelayCommand.setOnClickListener { presenter.onForwardWithDelayCommandClick() }
         binding.backToCommand.setOnClickListener { presenter.onBackToCommandClick() }
         binding.finishChainCommand.setOnClickListener { presenter.onFinishChainCommandClick() }
+        binding.forwardNccCommand.setOnClickListener { presenter.onForwardNccCommandClick() }
     }
 
     override fun setTitle(title: String) {

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SemiTransparentFragment.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SemiTransparentFragment.kt
@@ -1,0 +1,26 @@
+package com.github.terrakok.cicerone.sample.ui.main
+
+import android.os.Bundle
+import com.github.terrakok.cicerone.Router
+import com.github.terrakok.cicerone.sample.R
+import com.github.terrakok.cicerone.sample.SampleApplication
+import com.github.terrakok.cicerone.sample.ui.common.BackButtonListener
+import moxy.MvpAppCompatFragment
+import javax.inject.Inject
+
+class SemiTransparentFragment : MvpAppCompatFragment(R.layout.fragment_semitransparent),
+    BackButtonListener {
+
+    @Inject
+    lateinit var router: Router
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        SampleApplication.INSTANCE.appComponent.inject(this)
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onBackPressed(): Boolean {
+        router.exit()
+        return true
+    }
+}

--- a/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SemiTransparentFragment.kt
+++ b/sample/src/main/java/com/github/terrakok/cicerone/sample/ui/main/SemiTransparentFragment.kt
@@ -1,6 +1,8 @@
 package com.github.terrakok.cicerone.sample.ui.main
 
 import android.os.Bundle
+import android.view.View
+import android.widget.Button
 import com.github.terrakok.cicerone.Router
 import com.github.terrakok.cicerone.sample.R
 import com.github.terrakok.cicerone.sample.SampleApplication
@@ -17,6 +19,11 @@ class SemiTransparentFragment : MvpAppCompatFragment(R.layout.fragment_semitrans
     override fun onCreate(savedInstanceState: Bundle?) {
         SampleApplication.INSTANCE.appComponent.inject(this)
         super.onCreate(savedInstanceState)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Button>(R.id.back_button).setOnClickListener { onBackPressed() }
     }
 
     override fun onBackPressed(): Boolean {

--- a/sample/src/main/res/layout/fragment_sample.xml
+++ b/sample/src/main/res/layout/fragment_sample.xml
@@ -121,10 +121,20 @@
             android:layout_margin="4dp"
             android:layout_height="0dp"
             android:layout_rowWeight="1"
-            android:layout_columnSpan="2"
             android:background="@color/greensea"
             android:gravity="center"
             android:text="Finish chain"
+            android:textSize="28sp"/>
+        <TextView
+            android:id="@+id/forward_ncc_command"
+            android:layout_width="0dp"
+            android:layout_columnWeight="1"
+            android:layout_margin="4dp"
+            android:layout_height="0dp"
+            android:layout_rowWeight="1"
+            android:background="@color/nephritis"
+            android:gravity="center"
+            android:text="Forward not clearing container"
             android:textSize="28sp"/>
 
     </GridLayout>

--- a/sample/src/main/res/layout/fragment_semitransparent.xml
+++ b/sample/src/main/res/layout/fragment_semitransparent.xml
@@ -1,11 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/semitransparent">
-    <FrameLayout
+    android:background="@color/semitransparent"
+    tools:ignore="HardcodedText" >
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/accent"
-        android:layout_margin="40dp"/>
+        android:orientation="vertical"
+        android:layout_margin="40dp">
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="16dp"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:text="This is not a dialog.\n This is a regular screen."
+            />
+
+        <Button
+            android:id="@+id/back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:minWidth="100dp"
+            android:text="Back"
+            android:textAllCaps="false"
+            android:textSize="20sp"/>
+    </LinearLayout>
 </FrameLayout>

--- a/sample/src/main/res/layout/fragment_semitransparent.xml
+++ b/sample/src/main/res/layout/fragment_semitransparent.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/semitransparent">
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/accent"
+        android:layout_margin="40dp"/>
+</FrameLayout>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -4,6 +4,8 @@
     <color name="primary_dark">#c0392b</color>
     <color name="accent">#e67e22</color>
 
+    <color name="semitransparent">#99000000</color>
+
 
     <color name="alizarin">#e74c3c</color>
     <color name="carrot">#e67e22</color>


### PR DESCRIPTION
It seems to be useful having the example for overriding clearContainer property of FragmentScreen.
I've found it useful for keeping background fragment when opening new semitransparent.

If you had another idea while adding it - please let us know 