### PR TITLE
Make the ResultWire injectable parameter of the BaseRouter class

### DIFF
--- a/library/src/main/kotlin/com/github/terrakok/cicerone/BaseRouter.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/BaseRouter.kt
@@ -5,9 +5,9 @@ package com.github.terrakok.cicerone
  *
  * Extend it to add needed transition methods.
  */
-abstract class BaseRouter {
+abstract class BaseRouter(private val resultWire: ResultWire) {
     internal val commandBuffer = CommandBuffer()
-    private val resultWire = ResultWire()
+
 
     /**
      * Sets data listener with given key

--- a/library/src/main/kotlin/com/github/terrakok/cicerone/ResultWire.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/ResultWire.kt
@@ -14,7 +14,7 @@ fun interface ResultListenerHandler {
     fun dispose()
 }
 
-internal class ResultWire {
+class ResultWire {
     private val listeners = mutableMapOf<String, ResultListener>()
 
     fun setResultListener(key: String, listener: ResultListener): ResultListenerHandler {

--- a/library/src/main/kotlin/com/github/terrakok/cicerone/Router.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/Router.kt
@@ -7,7 +7,7 @@ package com.github.terrakok.cicerone
  * This implementation covers almost all cases needed for the average app.
  * Extend it if you need some tricky navigation.
  */
-open class Router : BaseRouter() {
+open class Router(resultWire: ResultWire = ResultWire()) : BaseRouter(resultWire) {
     /**
      * Open new screen and add it to the screens chain.
      *


### PR DESCRIPTION
The idea of PR - is to be able to inject the shared instance of ResultWire into separate Routers in order to send and receive the results across them.

I need this option in order to support complicated navigation cases in the multi-module project with bottom navigation where I need to keep several routers in parallel. 

Since the constructor of the Router class has default implementation - the change is fully compatible with previous versions and should not break and library usage