### PR TITLE
Add ability to clear plending navigation commands

### DIFF
--- a/library/src/main/kotlin/com/github/terrakok/cicerone/CommandBuffer.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/CommandBuffer.kt
@@ -22,6 +22,10 @@ internal class CommandBuffer : NavigatorHolder {
         navigator = null
     }
 
+    override fun clearPendingCommands() {
+        pendingCommands.clear()
+    }
+
     /**
      * Passes `commands` to the [Navigator] if it available.
      * Else puts it to the pending commands queue to pass it later.

--- a/library/src/main/kotlin/com/github/terrakok/cicerone/NavigatorHolder.kt
+++ b/library/src/main/kotlin/com/github/terrakok/cicerone/NavigatorHolder.kt
@@ -17,4 +17,9 @@ interface NavigatorHolder {
      * Remove the current Navigator and stop receive commands.
      */
     fun removeNavigator()
+
+    /**
+     * Clear pending commands.
+     */
+    fun clearPendingCommands()
 }


### PR DESCRIPTION
There was a need to clear the pending commands for example when activity is destroyed to prevent execute twice commands on activity start.